### PR TITLE
Fix InvalidOperationException in FundCard

### DIFF
--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -278,15 +278,19 @@ namespace PexCard.Api.Client
                 false, token);
 
             var tran = transactions.FindAll(
-                    x => x.TransactionTypeCategory == "CardFunding" && Convert.ToDecimal(x.TransactionAmount) == amount)
+                    x => x.TransactionTypeCategory == "CardFunding" && x.TransactionAmount == amount)
                 .OrderByDescending(x => x.TransactionTime)
-                .First();
+                .FirstOrDefault();
 
-            if (token.IsCancellationRequested)
+            if (tran != null)
             {
-                return fundingResult;
+                if (token.IsCancellationRequested)
+                {
+                    return fundingResult;
+                }
+
+                await AddTransactionNote(externalToken, tran, note, token);
             }
-            await AddTransactionNote(externalToken, tran, note, token);
 
             return fundingResult;
         }


### PR DESCRIPTION
Fix InvalidOperationException (Sequence contains no elements) when transaction isn't found (e.g., funding didn't succeed)