### PR TITLE
Fix build pipeline error at SonarCloudAnalyze step

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -32,12 +32,8 @@ steps:
     projectName: '$(Build.Repository.Name)'
     projectVersion: '$(Build.BuildNumber)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build'
-  inputs:
-    command: 'build'
-    projects: '**/*.csproj'
-    arguments: '--configuration $(buildConfiguration)'
+- script: dotnet publish --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory)
+  displayName: 'dotnet publish $(buildConfiguration)'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -66,6 +66,7 @@ steps:
     SourceFolder: $(Build.ArtifactStagingDirectory)
     Contents: |
       **/**
+      .*/**
 
 - script: dotnet pack src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory) -p:PackageVersion=$(versionNumber) -p:Version=$(versionNumber).0
   displayName: 'dotnet pack PexCard.Api.Client.Core.csproj'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -49,8 +49,11 @@ steps:
     pollingTimeoutSec: '300'
 
 - task: DeleteFiles@1
+  displayName: 'Clean Staging Directory'
   inputs:
-    Contents: $(Build.ArtifactStagingDirectory)/*
+    SourceFolder: $(Build.ArtifactStagingDirectory)
+    Contents: |
+      **/*
 
 - script: dotnet pack src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory) -p:PackageVersion=$(versionNumber) -p:Version=$(versionNumber).0
   displayName: 'dotnet pack PexCard.Api.Client.Core.csproj'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -48,12 +48,24 @@ steps:
   inputs:
     pollingTimeoutSec: '300'
 
+- task: WhiteSource@20
+  inputs:
+    cwd: '$(Build.ArtifactStagingDirectory)'
+    extensions: '.dll'
+    checkPolicies: 'FAIL_ON_BUILD'
+    productName: '$(System.TeamProject)'
+    projectRule: 'projectName'
+    projectName: '$(Build.Repository.Name)'
+    forceCheckAllDependencies: true
+    forceUpdate: true
+    WhiteSourceService: 'WhiteSource'
+
 - task: DeleteFiles@1
   displayName: 'Clean Staging Directory'
   inputs:
     SourceFolder: $(Build.ArtifactStagingDirectory)
     Contents: |
-      **/*
+      **/**
 
 - script: dotnet pack src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory) -p:PackageVersion=$(versionNumber) -p:Version=$(versionNumber).0
   displayName: 'dotnet pack PexCard.Api.Client.Core.csproj'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -48,6 +48,10 @@ steps:
   inputs:
     pollingTimeoutSec: '300'
 
+- task: DeleteFiles@1
+  inputs:
+    Contents: $(Build.ArtifactStagingDirectory)/*
+
 - script: dotnet pack src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj --configuration $(buildConfiguration) --output $(Build.ArtifactStagingDirectory) -p:PackageVersion=$(versionNumber) -p:Version=$(versionNumber).0
   displayName: 'dotnet pack PexCard.Api.Client.Core.csproj'
 


### PR DESCRIPTION
- Use `dotnet publish` instead of `dotnet build` as is done in the DEBUG pipeline
- Add missing WhiteSource step
- Clear ArtifactStagingDirectory before publishing artifacts, otherwise all output from `dotnet publish` will be published when we only want the 2 nuget packages