### PR TITLE
Populate Message property with direct error message instead of JSON

### DIFF
--- a/src/PexCard.Api.Client.Core/Models/ErrorMessageModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/ErrorMessageModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PexCard.Api.Client.Core.Models
+{
+    public class ErrorMessageModel
+    {
+        public string Message { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -479,7 +479,8 @@ namespace PexCard.Api.Client
                 {
                     return default(T);
                 }
-                throw new PexApiClientException(response.StatusCode, responseContent);
+                var errorModel = JsonConvert.DeserializeObject<ErrorMessageModel>(responseContent);
+                throw new PexApiClientException(response.StatusCode, errorModel.Message);
             }
             var result = JsonConvert.DeserializeObject<T>(responseContent);
             return result;
@@ -490,7 +491,8 @@ namespace PexCard.Api.Client
             if (!response.IsSuccessStatusCode)
             {
                 var responseContent = await response.Content.ReadAsStringAsync();
-                throw new PexApiClientException(response.StatusCode, responseContent);
+                var errorModel = JsonConvert.DeserializeObject<ErrorMessageModel>(responseContent);
+                throw new PexApiClientException(response.StatusCode, errorModel.Message);
             }
         }
         #endregion


### PR DESCRIPTION
Populate Message property with direct error message instead of JSON from PEX API