### PR TITLE
UpsertTags- sync tag names by default.

### DIFF
--- a/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
@@ -76,7 +76,7 @@ namespace PexCard.Api.Client.Core.Extensions
             ValidateDropdownTag(tag);
         }
 
-        public static void UpsertTagOptions(this TagDropdownDataModel tag, IEnumerable<IMatchableEntity> entities, out int syncCount, bool updateNames = false)
+        public static void UpsertTagOptions(this TagDropdownDataModel tag, IEnumerable<IMatchableEntity> entities, out int syncCount, bool updateNames = true)
         {
             syncCount = 0;
 

--- a/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
         }
 
         [Fact]
-        public void UpsertTagOptions_WithUpdateNameFalse_DoesNotUpdateExistingOption()
+        public void UpsertTagOptions_WithUpdateNamesFalse_DoesNotUpdateExistingOptionNames()
         {
             //Arrange
             var tagId = Guid.NewGuid().ToString();
@@ -156,7 +156,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
         }
 
         [Fact]
-        public void UpsertTagOptions_WithUpdateNameTrue_UpdatesExistingOption()
+        public void UpsertTagOptions_WithUpdateNamesTrue_UpdatesExistingOptionNames()
         {
             //Arrange
             var tagId = Guid.NewGuid().ToString();
@@ -184,6 +184,44 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
 
             //Act
             tag.UpsertTagOptions(new[] { exisintTagEntity }, out var syncCount, true);
+
+            //Assert
+            var onlyOption = tag.Options.SingleOrDefault();
+            Assert.NotNull(onlyOption);
+            Assert.Equal(1, syncCount);
+            Assert.Equal(tagId, onlyOption.Value);
+            Assert.Equal(newTagName, onlyOption.Name);
+        }
+
+        [Fact]
+        public void UpsertTagOptions_WithUpdateNamesDefault_UpdatesExistingOptionNames()
+        {
+            //Arrange
+            var tagId = Guid.NewGuid().ToString();
+            var tagName = "Test Option";
+            var newTagName = "New Test Option";
+            var existingTagOption = new TagOptionModel
+            {
+                Value = tagId,
+                Name = tagName,
+                IsEnabled = true
+            };
+            var exisintTagEntity = new TestEntity
+            {
+                Id = tagId,
+                Name = newTagName
+            };
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    existingTagOption
+                }
+            };
+
+            //Act
+            tag.UpsertTagOptions(new[] { exisintTagEntity }, out var syncCount);
 
             //Assert
             var onlyOption = tag.Options.SingleOrDefault();


### PR DESCRIPTION
# [AB#47487](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/47487) 
- DropdownTag option names should sync by default. Expected behavior.