### PR TITLE
ValidateDropdownTag: ignore case when validating tag option name/value uniqueness

### DIFF
--- a/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
@@ -143,7 +143,7 @@ namespace PexCard.Api.Client.Core.Extensions
             var duplicateTagOptionNamesOrValues = options.Where(x => options.Count(y => string.Equals(y.EntityName, x.EntityName, StringComparison.InvariantCultureIgnoreCase)) > 1 || options.Count(y => string.Equals(y.EntityId, x.EntityId, StringComparison.InvariantCultureIgnoreCase)) > 1).ToList();
             if (duplicateTagOptionNamesOrValues.Any())
             {
-                throw new DataException($"Duplicate tag option entity names ids and/or ids: {string.Join(", ", duplicateTagOptionNamesOrValues.Select(x => $"[EntityName: '{x.EntityName}', EntityId: '{x.EntityId}']"))}.");
+                throw new DataException($"Duplicate tag option entity names and/or ids: {string.Join(", ", duplicateTagOptionNamesOrValues.Select(x => $"[EntityName: '{x.EntityName}', EntityId: '{x.EntityId}']"))}.");
             }
         }
 

--- a/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
@@ -94,7 +94,7 @@ namespace PexCard.Api.Client.Core.Extensions
                 foreach (var entity in entitiesList)
                 {
                     // we only add new tag options (or update tag option NAMES if updateNames is true) and we do NOT change IsEnabled statuses.
-                    var option = tag.Options.Find(item => string.Equals(item.Value, entity.EntityId));
+                    var option = tag.Options.Find(item => string.Equals(item.Value, entity.EntityId, StringComparison.InvariantCultureIgnoreCase));
                     if (option != null)
                     {
                         if (updateNames && !string.Equals(option.Name, entity.EntityName))

--- a/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
@@ -131,7 +131,7 @@ namespace PexCard.Api.Client.Core.Extensions
                 throw new ArgumentNullException(nameof(tag));
             }
 
-            var duplicateTagOptionNamesOrValues = tag.Options.Where(x => tag.Options.Count(y => y.Name == x.Name) > 1 || tag.Options.Count(y => y.Value == x.Value) > 1).ToList();
+            var duplicateTagOptionNamesOrValues = tag.Options.Where(x => tag.Options.Count(y => string.Equals(y.Name, x.Name, StringComparison.InvariantCultureIgnoreCase)) > 1 || tag.Options.Count(y => string.Equals(y.Value, x.Value, StringComparison.InvariantCultureIgnoreCase)) > 1).ToList();
             if (duplicateTagOptionNamesOrValues.Any())
             {
                 throw new DataException($"{nameof(TagDropdownDataModel)} '{tag.Name}' has duplicate tag option names and/or values: {string.Join(", ", duplicateTagOptionNamesOrValues.Select(x => $"[Name: '{x.Name}', Value: '{x.Value}']"))}.");

--- a/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
@@ -12,6 +12,176 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
     public class TagExtensionsTests
     {
         [Fact]
+        public void UpsertTagOptions_WithDuplicateNamesSameCaseOptions_ThrowDataException()
+        {
+            //Arrange
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    new TagOptionModel
+                    {
+                        Value = "One",
+                        Name = "Foo"
+                    }
+                }
+            };
+            var tagOptions = new List<TagOptionEntity>
+            {
+                new TagOptionEntity
+                {
+                    Id = "Two",
+                    Name = "Foo"
+                },
+            };
+
+            //Act
+            var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
+
+            //Assert
+            Assert.Contains("has duplicate tag option names and/or values", ex.Message);
+        }
+
+        [Fact]
+        public void UpsertTagOptions_WithDuplicateNamesDiffCaseOptions_ThrowDataException()
+        {
+            //Arrange
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    new TagOptionModel
+                    {
+                        Value = "One",
+                        Name = "Foo"
+                    }
+                }
+            };
+            var tagOptions = new List<TagOptionEntity>
+            {
+                new TagOptionEntity
+                {
+                    Id = "Two",
+                    Name = "foo"
+                },
+            };
+
+            //Act
+            var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
+
+            //Assert
+            Assert.Contains("has duplicate tag option names and/or values", ex.Message);
+        }
+
+        [Fact]
+        public void UpsertTagOptions_WithDuplicateIdsDiffCaseOptions_ThrowDataException()
+        {
+            //Arrange
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    new TagOptionModel
+                    {
+                        Value = "One",
+                        Name = "Foo"
+                    }
+                }
+            };
+            var tagOptions = new List<TagOptionEntity>
+            {
+                new TagOptionEntity
+                {
+                    Id = "one",
+                    Name = "Bar"
+                },
+            };
+
+            //Act
+            var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
+
+            //Assert
+            Assert.Contains("has duplicate tag option names and/or values", ex.Message);
+        }
+
+        [Fact]
+        public void UpsertTagOptions_WithDuplicateIdsDiffCaseInUpdateOptions_ThrowDataException()
+        {
+            //Arrange
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    new TagOptionModel
+                    {
+                        Value = "One",
+                        Name = "Foo"
+                    }
+                }
+            };
+            var tagOptions = new List<TagOptionEntity>
+            {
+                new TagOptionEntity
+                {
+                    Id = "One",
+                    Name = "Bar1"
+                },
+                new TagOptionEntity
+                {
+                    Id = "one",
+                    Name = "Bar2"
+                },
+            };
+
+            //Act
+            var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
+
+            //Assert
+            Assert.Contains("Duplicate tag option entity names ids and/or ids", ex.Message);
+        }
+
+        [Fact]
+        public void UpsertTagOptions_WithDuplicateNamesDiffCaseInUpdateOptions_ThrowDataException()
+        {
+            //Arrange
+            var tag = new TagDropdownDataModel
+            {
+                Name = "Test Tag",
+                Options = new List<TagOptionModel>
+                {
+                    new TagOptionModel
+                    {
+                        Value = "One",
+                        Name = "Foo"
+                    }
+                }
+            };
+            var tagOptions = new List<TagOptionEntity>
+            {
+                new TagOptionEntity
+                {
+                    Id = "Two",
+                    Name = "Bar1"
+                },
+                new TagOptionEntity
+                {
+                    Id = "Three",
+                    Name = "bar1"
+                },
+            };
+
+            //Act
+            var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
+
+            //Assert
+            Assert.Contains("Duplicate tag option entity names ids and/or ids", ex.Message);
+        }
+
+        [Fact]
         public void UpsertTagOptions_WithNullOptions_ThrowDataException()
         {
             //Arrange
@@ -96,7 +266,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             //Arrange
             var tagId = Guid.NewGuid().ToString();
             var tagName = "Test Option";
-            var newTagEntity = new TestEntity
+            var newTagEntity = new TagOptionEntity
             {
                 Id = tagId,
                 Name = tagName
@@ -130,7 +300,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
                 Name = tagName,
                 IsEnabled = true
             };
-            var exisintTagEntity = new TestEntity
+            var exisintTagEntity = new TagOptionEntity
             {
                 Id = tagId,
                 Name = tagName
@@ -168,7 +338,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
                 Name = tagName,
                 IsEnabled = true
             };
-            var exisintTagEntity = new TestEntity
+            var exisintTagEntity = new TagOptionEntity
             {
                 Id = tagId,
                 Name = newTagName
@@ -206,7 +376,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
                 Name = tagName,
                 IsEnabled = true
             };
-            var exisintTagEntity = new TestEntity
+            var exisintTagEntity = new TagOptionEntity
             {
                 Id = tagId,
                 Name = newTagName
@@ -231,7 +401,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             Assert.Equal(newTagName, onlyOption.Name);
         }
 
-        private class TestEntity : IMatchableEntity
+        private class TagOptionEntity : IMatchableEntity
         {
             public string Id { get; set; }
 

--- a/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Extensions/TagExtensionsTests.cs
@@ -96,6 +96,11 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
                 new TagOptionEntity
                 {
                     Id = "one",
+                    Name = "foo"
+                },
+                new TagOptionEntity
+                {
+                    Id = "One",
                     Name = "Bar"
                 },
             };
@@ -104,7 +109,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
 
             //Assert
-            Assert.Contains("has duplicate tag option names and/or values", ex.Message);
+            Assert.Contains("Duplicate tag option entity names and/or ids", ex.Message);
         }
 
         [Fact]
@@ -141,7 +146,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
 
             //Assert
-            Assert.Contains("Duplicate tag option entity names ids and/or ids", ex.Message);
+            Assert.Contains("Duplicate tag option entity names and/or ids", ex.Message);
         }
 
         [Fact]
@@ -178,7 +183,7 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             var ex = Assert.Throws<DataException>(() => tag.UpsertTagOptions(tagOptions, out var syncCount));
 
             //Assert
-            Assert.Contains("Duplicate tag option entity names ids and/or ids", ex.Message);
+            Assert.Contains("Duplicate tag option entity names and/or ids", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
[AB#48030](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/48030)
- Tag names and values must be distinct regardless of case (as done in dashboard and external API).