### PR TITLE
Add Extra Cardholder Properties to GET BusinessDetails

### DIFF
--- a/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
@@ -58,6 +58,11 @@ namespace PexCard.Api.Client.Core.Models
         public string GroupName { get; set; }
 
         /// <summary>
+        /// Cardholder's active card status (NULL, Active, Inactive, Closed, Blocked).
+        /// </summary>
+        public string CardStatus { get; set; }
+
+        /// <summary>
         /// Cardholder's active card's last 4 digits.
         /// </summary>
         public string CardNumber4Digits { get; set; }

--- a/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
@@ -65,11 +65,11 @@ namespace PexCard.Api.Client.Core.Models
         /// <summary>
         /// Cardhodler's active card's issue date.
         /// </summary>
-        public DateTime CardIssueDate { get; set; }
+        public DateTime? CardIssueDate { get; set; }
 
         /// <summary>
         /// Cardhodler's active card's expiry date.
         /// </summary>
-        public DateTime CardExpiryDate { get; set; }
+        public DateTime? CardExpiryDate { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
@@ -68,12 +68,12 @@ namespace PexCard.Api.Client.Core.Models
         public string CardNumber4Digits { get; set; }
 
         /// <summary>
-        /// Cardhodler's active card's issue date.
+        /// Cardholder's active card's issue date.
         /// </summary>
         public DateTime? CardIssueDate { get; set; }
 
         /// <summary>
-        /// Cardhodler's active card's expiry date.
+        /// Cardholder's active card's expiry date.
         /// </summary>
         public DateTime? CardExpiryDate { get; set; }
     }

--- a/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
@@ -1,4 +1,6 @@
-﻿namespace PexCard.Api.Client.Core.Models
+﻿using System;
+
+namespace PexCard.Api.Client.Core.Models
 {
     public class CardholderAccountModel
     {
@@ -44,5 +46,30 @@
         /// (alphanumeric up to 50 characters)
         /// </summary>
         public string CustomId { get; set; }
+
+        /// <summary>
+        /// Cardholder's group id.
+        /// </summary>
+        public int? GroupId { get; set; }
+
+        /// <summary>
+        /// Cardholder's group name.
+        /// </summary>
+        public string GroupName { get; set; }
+
+        /// <summary>
+        /// Cardholder's active card's last 4 digits.
+        /// </summary>
+        public string CardNumber4Digits { get; set; }
+
+        /// <summary>
+        /// Cardhodler's active card's issue date.
+        /// </summary>
+        public DateTime CardIssueDate { get; set; }
+
+        /// <summary>
+        /// Cardhodler's active card's expiry date.
+        /// </summary>
+        public DateTime CardExpiryDate { get; set; }
     }
 }


### PR DESCRIPTION
[AB#47788](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/47788)

- add the following columns that were added to the External API
  - GroupId
  - GroupName
  - CardStatus
  - CardNumber4Digits
  - CardIssueDate
  - CardExpiryDate