### PR TITLE
NuGet Downgrades/Upgrades

### DIFF
--- a/src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj
+++ b/src/PexCard.Api.Client.Core/PexCard.Api.Client.Core.csproj
@@ -17,9 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/PexCard.Api.Client/PexCard.Api.Client.csproj
+++ b/src/PexCard.Api.Client/PexCard.Api.Client.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PexCard.Api.Client.Core.Tests/PexCard.Api.Client.Core.Tests.csproj
+++ b/tests/PexCard.Api.Client.Core.Tests/PexCard.Api.Client.Core.Tests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
[AB#51463](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/51463)

- Downgrade `Microsoft.Extensions.Logging.Abstractions` to `3.x`
- Upgrade other NuGet packages to latest versions:
  - `Microsoft.SourceLink.GitHub`
  - `coverlet.collector`
  - `Moq`