### PR TITLE
#AB54254 - Fix Cardholder Group Response Models

### DIFF
--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -108,13 +108,13 @@ namespace PexCard.Api.Client.Core
         Task<PartnerModel> GetPartner(string externalToken, CancellationToken token = default(CancellationToken));
         Task<TokenDataModel> GetToken(string externalToken, CancellationToken cancellationToken = default);
 
-        Task<List<CardholderGroupModel>> GetCardholderGroups(string externalToken, CancellationToken token = default);
+        Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken token = default);
 
-        Task<CardholderGroupModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken token = default);
 
-        Task<CardholderGroupModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken token = default);
 
-        Task<CardholderGroupModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken token = default);
 
         Task DeleteCardholderGroup(string externalToken, int groupId, CancellationToken token = default);
     }

--- a/src/PexCard.Api.Client.Core/Models/CardholderGroupResponseModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderGroupResponseModel.cs
@@ -1,0 +1,7 @@
+﻿namespace PexCard.Api.Client.Core.Models
+{
+    public class CardholderGroupResponseModel
+    {
+        public CardholderGroupModel Group { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/CardholderGroupsResponseModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderGroupsResponseModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace PexCard.Api.Client.Core.Models
+{
+    public class CardholderGroupsResponseModel
+    {
+        public List<CardholderGroupModel> Groups { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -468,27 +468,27 @@ namespace PexCard.Api.Client
             return result;
         }
 
-        public async Task<List<CardholderGroupModel>> GetCardholderGroups(string externalToken, CancellationToken token = default)
+        public async Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken token = default)
         {
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
 
             var response = await _httpClient.GetAsync($"v4/Group", token);
-            var result = await HandleHttpResponseMessage<List<CardholderGroupModel>>(response);
+            var result = await HandleHttpResponseMessage<CardholderGroupsResponseModel>(response);
 
             return result;
         }
 
-        public async Task<CardholderGroupModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken token = default)
+        public async Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken token = default)
         {
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
 
             var response = await _httpClient.GetAsync($"v4/Group/{groupId}", token);
-            var result = await HandleHttpResponseMessage<CardholderGroupModel>(response);
+            var result = await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
 
             return result;
         }
 
-        public async Task<CardholderGroupModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken token = default)
+        public async Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken token = default)
         {
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
 
@@ -496,12 +496,12 @@ namespace PexCard.Api.Client
             var request = new StringContent(requestContent, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PostAsync("V4/Group", request, token);
-            var result = await HandleHttpResponseMessage<CardholderGroupModel>(response);
+            var result = await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
 
             return result;
         }
 
-        public async Task<CardholderGroupModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken token = default)
+        public async Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken token = default)
         {
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
 
@@ -509,7 +509,7 @@ namespace PexCard.Api.Client
             var request = new StringContent(requestContent, Encoding.UTF8, "application/json");
 
             var response = await _httpClient.PutAsync($"V4/Group/{groupId}", request, token);
-            var result = await HandleHttpResponseMessage<CardholderGroupModel>(response);
+            var result = await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
 
             return result;
         }


### PR DESCRIPTION
As per [AB#54254](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/54254) - responses are wrapped in an extra object.