### PR TITLE
Improvements - Entity Matching Algorithm & TagExtensions Improvements

### DIFF
--- a/src/PexCard.Api.Client.Core/Extensions/MatchingExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/MatchingExtension.cs
@@ -65,8 +65,8 @@ namespace PexCard.Api.Client.Core.Extensions
             T entityIdMatchedByValue = default;
             T entityNameMatchedByName = default;
             T entityNameMatchedByValue = default;
-            T entityNameMatchedByNameHeirarchy = default;
-            T entityNameMatchedByValueHeirarchy = default;
+            T entityNameMatchedByNameHierarchy = default;
+            T entityNameMatchedByValueHierarchy = default;
 
             int entityNameMatchedByNameHierarchyLevel = default;
             int entityNameMatchedByValueHierarchyLevel = default;
@@ -107,7 +107,7 @@ namespace PexCard.Api.Client.Core.Extensions
 
                     if (currentHierarchyLevel > entityNameMatchedByNameHierarchyLevel)
                     {
-                        entityNameMatchedByNameHeirarchy = entity;
+                        entityNameMatchedByNameHierarchy = entity;
                         entityNameMatchedByNameHierarchyLevel = currentHierarchyLevel;
                     }
                 }
@@ -120,7 +120,7 @@ namespace PexCard.Api.Client.Core.Extensions
 
                     if (currentHierarchyLevel > entityNameMatchedByValueHierarchyLevel)
                     {
-                        entityNameMatchedByValueHeirarchy = entity;
+                        entityNameMatchedByValueHierarchy = entity;
                         entityNameMatchedByValueHierarchyLevel = currentHierarchyLevel;
                     }
                 }
@@ -130,10 +130,10 @@ namespace PexCard.Api.Client.Core.Extensions
             // - if we matched entity id by value arg
             // - if we matched by entity name from name arg
             // - if we matched by entity name from value arg
-            // - if we matched by entity name from name arg using heirarchy+delimiter
-            // - if we matched by entity name from value arg using heirarchy+delimiter
+            // - if we matched by entity name from name arg using Hierarchy+delimiter
+            // - if we matched by entity name from value arg using Hierarchy+delimiter
 
-            return entityIdMatchedByValue ?? entityNameMatchedByName ?? entityNameMatchedByValue ?? entityNameMatchedByNameHeirarchy ?? entityNameMatchedByValueHeirarchy;
+            return entityIdMatchedByValue ?? entityNameMatchedByName ?? entityNameMatchedByValue ?? entityNameMatchedByNameHierarchy ?? entityNameMatchedByValueHierarchy;
         }
     }
 }

--- a/src/PexCard.Api.Client.Core/Extensions/MatchingExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/MatchingExtension.cs
@@ -8,23 +8,20 @@ namespace PexCard.Api.Client.Core.Extensions
 {
     public static class MatchingExtension
     {
-        public static T MatchEntityByName<T>(
-            this IEnumerable<T> entities,
-            string entityName,
-            char delimiter = default(char)) where T : IMatchableEntity
+        public static T MatchEntityByName<T>(this IEnumerable<T> entities, string name, char delimiter = default(char)) where T : IMatchableEntity
         {
-            if (string.IsNullOrEmpty(entityName)) return default(T);
+            if (string.IsNullOrEmpty(name)) return default(T);
 
             List<T> matchedEntities;
             if (delimiter == default(char))
             {
-                matchedEntities = entities.Where(x => string.Equals(x.EntityName, entityName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                matchedEntities = entities.Where(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase)).ToList();
                 return matchedEntities.FirstOrDefault();
             }
 
             matchedEntities = entities
-                .Where(x => string.Equals(x.EntityName, entityName, StringComparison.InvariantCultureIgnoreCase) ||
-                            x.EntityName?.EndsWith($"{delimiter}{entityName}", StringComparison.InvariantCultureIgnoreCase) == true)
+                .Where(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase) ||
+                            x.EntityName?.EndsWith($"{delimiter}{name}", StringComparison.InvariantCultureIgnoreCase) == true)
                 .ToList();
 
             if (!matchedEntities.Any()) return default(T);
@@ -35,14 +32,15 @@ namespace PexCard.Api.Client.Core.Extensions
             }
 
             var exactlyMatchedEntities = matchedEntities
-                .Where(x => string.Equals(x.EntityName, entityName, StringComparison.InvariantCultureIgnoreCase))
+                .Where(x => string.Equals(x.EntityName, name, StringComparison.InvariantCultureIgnoreCase))
                 .ToList();
+
             if (exactlyMatchedEntities.Count == 1)
             {
                 return exactlyMatchedEntities.First();
             }
 
-            //Try to match entity name on the deepest chunk with PEX tag option name
+            // Try to match entity name on the deepest chunk with PEX tag option name
             // e.g.
             // PEX tag option name is "One".
             // Entities are following: "1 One", "2 Expense:One" and "3 Expense:Category:One"
@@ -51,64 +49,91 @@ namespace PexCard.Api.Client.Core.Extensions
                 .GroupBy(c => c.EntityName?.Count(x => x == delimiter))
                 .ToList();
             var maxKey = groupedEntities.Max(c => c.Key);
+
             return groupedEntities.First(e => e.Key == maxKey).First();
         }
 
-        public static T FindMatchingEntity<T>(
-            this IEnumerable<T> entities,
-            string entityValue,
-            string entityName,
-            char entityNameHierarchyDelimiter = default,
-            ILogger logger = default)
-                where T : class, IMatchableEntity
+        public static T FindMatchingEntity<T>(this IEnumerable<T> entities, string value, string name, char entityNameHierarchyDelimiter = default, ILogger logger = default) where T : class, IMatchableEntity
         {
             if (entities == null)
             {
                 return null;
             }
 
-            logger?.LogInformation($"Searching for a match for value '{entityValue}' / name '{entityName}' in {entities.Count()} entities");
+            logger?.LogInformation($"Searching {entities.Count()} entities for a match using using value arg '{value}' and name arg '{name}'.");
 
-            T entityMatchedByValue = default;
-            T entityMatchedByName = default;
-            T entityMatchedByNameHierarchy = default;
-            int entityMatchedByNameHierarchyLevel = default;
+            T entityIdMatchedByValue = default;
+            T entityNameMatchedByName = default;
+            T entityNameMatchedByValue = default;
+            T entityNameMatchedByNameHeirarchy = default;
+            T entityNameMatchedByValueHeirarchy = default;
+
+            int entityNameMatchedByNameHierarchyLevel = default;
+            int entityNameMatchedByValueHierarchyLevel = default;
+
             foreach (T entity in entities)
             {
-                logger?.LogDebug($"Searching against entity: '{entity.EntityId}' / '{entity.EntityName}'");
+                logger?.LogDebug($"Attemping to match entity '{entity.EntityName}' ({entity.EntityId}) using value arg '{value}' and name arg '{name}'.");
 
-                if (string.Equals(entity.EntityId, entityValue, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(entity.EntityId, value, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    //If there is an exact match on Id, use the first match.
-                    logger?.LogDebug($"Matched on value");
-                    entityMatchedByValue = entity;
+                    // if there is an exact match on entity id from value arg, stop searching. we have an exact match.
+                    logger?.LogDebug($"Matched entity '{entity.EntityName}' by entity-id and value arg '{value}'. Done searching.");
+                    entityIdMatchedByValue = entity;
                     break;
                 }
 
-                if (string.Equals(entity.EntityName, entityName, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(entity.EntityName, name, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    //If there is an exact match on Name, use it unless we find an Id match later.
-                    logger?.LogDebug($"Matched on name");
-                    entityMatchedByName = entity;
+                    // if there is an exact match on entity name from name arg, use it unless we find an better match later
+                    logger?.LogDebug($"Matched entity '{entity.EntityName}' by entity-name and name arg '{name}'.");
+                    entityNameMatchedByName = entity;
                     continue;
                 }
 
-                if (entityNameHierarchyDelimiter != default
-                    && entity.EntityName?.EndsWith($"{entityNameHierarchyDelimiter}{entityName}", StringComparison.InvariantCultureIgnoreCase) == true)
+                if (string.Equals(entity.EntityName, value, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    //If there is a match on a child entity name, use the most specific one unless there is an exact match on Id or Name later.
-                    var currentHierarchyLevel = entity.EntityName.Count(x => x == entityNameHierarchyDelimiter);
-                    logger?.LogDebug($"Matched on name (delimiter) ({currentHierarchyLevel} levels)");
+                    // if there is an exact match on entity name from value arg, use it unless we find an better match later
+                    logger?.LogDebug($"Matched entity '{entity.EntityName}' by entity-name and value arg '{value}'.");
+                    entityNameMatchedByValue = entity;
+                    continue;
+                }
 
-                    if (currentHierarchyLevel > entityMatchedByNameHierarchyLevel)
+                if (entityNameHierarchyDelimiter != default && entity.EntityName?.EndsWith($"{entityNameHierarchyDelimiter}{name}", StringComparison.InvariantCultureIgnoreCase) == true)
+                {
+                    // if there is a match on a child entity name from name arg, use the most specific one unless we find an better match later
+                    var currentHierarchyLevel = entity.EntityName.Count(x => x == entityNameHierarchyDelimiter);
+                    logger?.LogDebug($"Matched entity '{entity.EntityName}' by entity-name and name arg '{name}' using delimiter matching ('{entityNameHierarchyDelimiter}') on {currentHierarchyLevel} levels.");
+
+                    if (currentHierarchyLevel > entityNameMatchedByNameHierarchyLevel)
                     {
-                        entityMatchedByNameHierarchy = entity;
-                        entityMatchedByNameHierarchyLevel = currentHierarchyLevel;
+                        entityNameMatchedByNameHeirarchy = entity;
+                        entityNameMatchedByNameHierarchyLevel = currentHierarchyLevel;
+                    }
+                }
+
+                if (entityNameHierarchyDelimiter != default && entity.EntityName?.EndsWith($"{entityNameHierarchyDelimiter}{value}", StringComparison.InvariantCultureIgnoreCase) == true)
+                {
+                    // if there is a match on a child entity name from value arg, use the most specific one unless we find an better match later
+                    var currentHierarchyLevel = entity.EntityName.Count(x => x == entityNameHierarchyDelimiter);
+                    logger?.LogDebug($"Matched entity '{entity.EntityName}' by entity-name and value arg '{value}' using delimiter matching ('{entityNameHierarchyDelimiter}') on {currentHierarchyLevel} levels.");
+
+                    if (currentHierarchyLevel > entityNameMatchedByValueHierarchyLevel)
+                    {
+                        entityNameMatchedByValueHeirarchy = entity;
+                        entityNameMatchedByValueHierarchyLevel = currentHierarchyLevel;
                     }
                 }
             }
 
-            return entityMatchedByValue ?? entityMatchedByName ?? entityMatchedByNameHierarchy;
+            // order of matching fallbacks:
+            // - if we matched entity id by value arg
+            // - if we matched by entity name from name arg
+            // - if we matched by entity name from value arg
+            // - if we matched by entity name from name arg using heirarchy+delimiter
+            // - if we matched by entity name from value arg using heirarchy+delimiter
+
+            return entityIdMatchedByValue ?? entityNameMatchedByName ?? entityNameMatchedByValue ?? entityNameMatchedByNameHeirarchy ?? entityNameMatchedByValueHeirarchy;
         }
     }
 }

--- a/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs
@@ -13,6 +13,8 @@ namespace PexCard.Api.Client.Core.Extensions
             this TransactionTagModel transactionTag,
             IEnumerable<TagOptionModel> tagOptions)
         {
+            if (transactionTag == null) return null;
+
             var result = tagOptions
                 ?.FirstOrDefault(o => o.Value.Equals(transactionTag.Value))
                 ?.Name;
@@ -23,6 +25,8 @@ namespace PexCard.Api.Client.Core.Extensions
             this TagValueItem transactionTag,
             IEnumerable<TagOptionModel> tagOptions)
         {
+            if (transactionTag == null) return null;
+            
             var result = tagOptions
                 ?.FirstOrDefault(o => o.Value.Equals(transactionTag.Value))
                 ?.Name;

--- a/tests/PexCard.Api.Client.Core.Tests/Extensions/MatchingExtensionsTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Extensions/MatchingExtensionsTests.cs
@@ -147,6 +147,91 @@ namespace PexCard.Api.Client.Core.Tests.Extensions
             Assert.Equal(testEntity, newMatchedEntity);
         }
 
+        [Fact]
+        public void FindMatchingEntity_MatchesOnNameFromName()
+        {
+            const string entityName = "Match Me";
+
+            //Arrange
+            var testEntity = new TestTagOption
+            {
+                OptionValue = "1",
+                OptionName = entityName
+            };
+            var entities = new[]
+            {
+                new TestTagOption
+                {
+                    OptionValue = "2",
+                    OptionName = "Shouldn't Match Me"
+                },
+                testEntity
+            };
+
+            //Act
+            var newMatchedEntity = entities.FindMatchingEntity("XXX", entityName);
+
+            //Assert
+            Assert.Equal(testEntity, newMatchedEntity);
+        }
+
+        [Fact]
+        public void FindMatchingEntity_MatchesOnNameFromValue()
+        {
+            const string entityName = "Match Me";
+
+            //Arrange
+            var testEntity = new TestTagOption
+            {
+                OptionValue = "1",
+                OptionName = entityName
+            };
+            var entities = new[]
+            {
+                new TestTagOption
+                {
+                    OptionValue = "2",
+                    OptionName = "Shouldn't Match Me"
+                },
+                testEntity
+            };
+
+            //Act
+            var newMatchedEntity = entities.FindMatchingEntity(entityName, "XXX");
+
+            //Assert
+            Assert.Equal(testEntity, newMatchedEntity);
+        }
+
+
+        [Fact]
+        public void FindMatchingEntity_MatchesOnNameFromNameFirst()
+        {
+            const string entityName = "Match Me";
+
+            //Arrange
+            var testEntity = new TestTagOption
+            {
+                OptionValue = "1",
+                OptionName = entityName
+            };
+            var entities = new[]
+            {
+                new TestTagOption
+                {
+                    OptionValue = entityName,
+                    OptionName = "Shouldn't Match Me"
+                },
+                testEntity
+            };
+
+            //Act
+            var newMatchedEntity = entities.FindMatchingEntity("XXX", entityName);
+
+            //Assert
+            Assert.Equal(testEntity, newMatchedEntity);
+        }
+
         private class TestTagOption : IMatchableEntity
         {
             public string OptionValue { get; set; }


### PR DESCRIPTION
[AB#58302](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/58302)
> As an SDK user, I want my external entities to match from tags by matching with the correct entity id in the tag option value, or by matching the correct entity name from the tag option value OR tag option name.

[AB#58148](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/58148)
>System.NullReferenceException: Object reference not set to an instance of an object.
   at PexCard.Api.Client.Core.Extensions.TagExtension.<>c__DisplayClass1_0.<GetTagOptionName>b__0(TagOptionModel o) in /_/src/PexCard.Api.Client.Core/Extensions/TagExtension.cs:line 27
