### PR TITLE
PEX API Client Thread Safety

### DIFF
--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -10,126 +10,91 @@ namespace PexCard.Api.Client.Core
     public interface IPexApiClient
     {
         Uri BaseUri { get; }
-        Task<bool> Ping(CancellationToken token = default(CancellationToken));
 
-        Task<RenewTokenResponseModel> RenewExternalToken(string externalToken, CancellationToken token = default(CancellationToken));
-        Task DeleteExternalToken(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<decimal> GetPexAccountBalance(string externalToken, CancellationToken token = default(CancellationToken));
+        Task<bool> Ping(CancellationToken cancelToken = default);
 
-        Task<int> GetAllCardholderTransactionsCount(
-            string externalToken,
-            DateTime startDate,
-            DateTime endDate,
-            bool includePendings = false,
-            bool includeDeclines = false,
-            CancellationToken token = default(CancellationToken));
+        Task<PartnerModel> GetPartner(string externalToken, CancellationToken cancelToken = default);
 
-        Task<CardholderTransactions> GetAllCardholderTransactions(
-            string externalToken,
-            DateTime startDate,
-            DateTime endDate,
-            bool includePendings = false,
-            bool includeDeclines = false,
-            CancellationToken token = default(CancellationToken));
+        Task<TokenDataModel> GetToken(string externalToken, CancellationToken cancelToken = default);
 
-        Task<BusinessAccountTransactions> GetBusinessAccountTransactions(
-            string externalToken,
-            DateTime startDate,
-            DateTime endDate,
-            bool includePendings = false,
-            bool includeDeclines = false,
-            CancellationToken token = default(CancellationToken));
+        Task<TokenResponseModel> GetTokens(string externalToken, CancellationToken cancelToken = default);
 
-        Task<List<AttachmentLinkModel>> GetTransactionAttachments(string externalToken, long transactionId,
-            CancellationToken token = default(CancellationToken));
+        Task<RenewTokenResponseModel> RenewExternalToken(string externalToken, CancellationToken cancelToken = default);
 
-        Task<AttachmentModel> GetTransactionAttachment(string externalToken, long transactionId,
-            string attachmentId, CancellationToken token = default(CancellationToken));
+        Task DeleteExternalToken(string externalToken, CancellationToken cancelToken = default);
 
-        Task AddTransactionNote(string externalToken, TransactionModel transaction, string noteText,
-            CancellationToken token = default(CancellationToken));
+        Task<string> ExchangeJwtForApiToken(string jwt, ExchangeTokenRequestModel exchangeTokenRequest, CancellationToken cancelToken = default);
 
-        Task<bool> IsTagsEnabled(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<bool> IsTagsAvailable(string externalToken, CustomFieldType fieldType, CancellationToken token = default(CancellationToken));
+        Task<GetAdminProfileModel> GetMyAdminProfile(string externalToken, CancellationToken cancelToken = default);
 
-        Task<GetAdminProfileModel> GetMyAdminProfile(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<BusinessDetailsModel> GetBusinessDetails(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<BusinessSettingsModel> GetBusinessSettings(string externalToken, CancellationToken token = default(CancellationToken));
+        Task<BusinessDetailsModel> GetBusinessDetails(string externalToken, CancellationToken cancelToken = default);
 
-        Task<CardholderDetailsModel> GetCardholderDetails(string externalToken, int cardholderAccountId,
-            CancellationToken token = default(CancellationToken));
+        Task<BusinessSettingsModel> GetBusinessSettings(string externalToken, CancellationToken cancelToken = default);
 
-        Task<CardholderProfileModel> GetCardholderProfile(string externalToken, int cardholderAccountId,
-            CancellationToken token = default(CancellationToken));
+        Task<decimal> GetPexAccountBalance(string externalToken, CancellationToken cancelToken = default);
 
-        Task<List<TagDetailsModel>> GetTags(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<TagDetailsModel> GetTag(string externalToken, string tagId, CancellationToken token = default(CancellationToken));
-        Task<TagDropdownDetailsModel> GetDropdownTag(string externalToken, string tagId,
-            CancellationToken token = default(CancellationToken));
-        Task<TagDropdownDetailsModel> CreateDropdownTag(string externalToken, TagDropdownDataModel tag,
-            CancellationToken token = default(CancellationToken));
-        Task<TagDropdownDetailsModel> UpdateDropdownTag(string externalToken, string tagId, TagDropdownModel tag,
-            CancellationToken token = default(CancellationToken));
-        Task<TagDropdownDetailsModel> DeleteDropdownTag(string externalToken, string tagId,
-            CancellationToken token = default(CancellationToken));
+        Task<BusinessAccountTransactions> GetBusinessAccountTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 
-        Task<string> ExchangeJwtForApiToken(string jwt, ExchangeTokenRequestModel exchangeTokenRequest,
-            CancellationToken cancellationToken = default(CancellationToken));
+        Task<int> GetAllCardholderTransactionsCount(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 
-        Task<FundResponseModel> FundCard(string externalToken, int cardholderAccountId, decimal amount,
-            string note = "", CancellationToken token = default(CancellationToken));
+        Task<CardholderTransactions> GetAllCardholderTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 
-        Task<CardholderTransactions> GetCardholderTransactions(
-            string externalToken,
-            int cardholderAccountId,
-            DateTime startDate,
-            DateTime endDate,
-            bool includePending = false,
-            bool includeDeclines = false,
-            CancellationToken token = default(CancellationToken));
+        Task<CardholderTransactions> GetCardholderTransactions(string externalToken, int cardholderAccountId, DateTime startDate, DateTime endDate, bool includePending = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 
-        /// <summary>
-        /// Returns a list of tokens for the associated business.
-        /// Determine which API user a token belongs to, as well as the token expiration date.
-        /// </summary>
-        Task<TokenResponseModel> GetTokens(string externalToken, CancellationToken token = default(CancellationToken));
+        Task AddTransactionNote(string externalToken, TransactionModel transaction, string noteText, CancellationToken cancelToken = default);
 
-        /// <summary>
-        /// Fund a specified card accountID to zero ($0).
-        /// </summary>
-        Task<FundResponseModel> ZeroCard(string externalToken, int cardholderAccountId, CancellationToken token = default);
+        Task<List<AttachmentLinkModel>> GetTransactionAttachments(string externalToken, long transactionId, CancellationToken cancelToken = default);
 
-        /// <summary>
-        /// Create a new card order. This will create new cardholder accounts within your PEX account.
-        /// </summary>
-        Task<int> CreateCardOrder(string externalToken, CardOrderModel cardOrder,
-            CancellationToken token = default(CancellationToken));
+        Task<AttachmentModel> GetTransactionAttachment(string externalToken, long transactionId, string attachmentId, CancellationToken cancelToken = default);
 
-        Task<PartnerModel> GetPartner(string externalToken, CancellationToken token = default(CancellationToken));
-        Task<TokenDataModel> GetToken(string externalToken, CancellationToken cancellationToken = default);
+        Task<TagsModel> GetTransactionTags(string externalToken, long transactionId, CancellationToken cancelToken = default);
 
-        Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken token = default);
+        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default);
 
-        Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken token = default);
+        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default);
 
-        Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken token = default);
+        Task<CardholderDetailsModel> GetCardholderDetails(string externalToken, int cardholderAccountId, CancellationToken cancelToken = default);
 
-        Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken token = default);
+        Task<CardholderProfileModel> GetCardholderProfile(string externalToken, int cardholderAccountId, CancellationToken cancelToken = default);
 
-        Task DeleteCardholderGroup(string externalToken, int groupId, CancellationToken token = default);
+        Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken cancelToken = default);
 
-        Task<TagsModel> GetTransactionTags(string externalToken, long transactionId, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default);
 
-        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken cancelToken = default);
 
-        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken token = default);
+        Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken cancelToken = default);
 
-        Task<List<CallbackSubscriptionModel>> GetCallbackSubscriptions(string externalToken, CancellationToken token = default);
+        Task DeleteCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default);
 
-        Task<CallbackSubscriptionModel> GetCallbackSubscription(string externalToken, int callbackId, CancellationToken token = default);
+        Task<int> CreateCardOrder(string externalToken, CardOrderModel cardOrder, CancellationToken cancelToken = default);
 
-        Task AddCallbackSubscription(string externalToken, CallbackType callbackType, Uri callbackUri, CallbackStatus callbackStatus = CallbackStatus.Active, CancellationToken token = default);
+        Task<FundResponseModel> FundCard(string externalToken, int cardholderAccountId, decimal amount, string note = "", CancellationToken cancelToken = default);
 
-        Task UpdateCallbackSubscription(string externalToken, int callbackId, CallbackType callbackType, Uri callbackUri, CallbackStatus callbackStatus, CancellationToken token = default);
+        Task<FundResponseModel> ZeroCard(string externalToken, int cardholderAccountId, CancellationToken cancelToken = default);
+
+        Task<bool> IsTagsEnabled(string externalToken, CancellationToken cancelToken = default);
+
+        Task<bool> IsTagsAvailable(string externalToken, CustomFieldType fieldType, CancellationToken cancelToken = default);
+
+        Task<List<TagDetailsModel>> GetTags(string externalToken, CancellationToken cancelToken = default);
+
+        Task<TagDetailsModel> GetTag(string externalToken, string tagId, CancellationToken cancelToken = default);
+
+        Task<TagDropdownDetailsModel> GetDropdownTag(string externalToken, string tagId, CancellationToken cancelToken = default);
+
+        Task<TagDropdownDetailsModel> CreateDropdownTag(string externalToken, TagDropdownDataModel tag, CancellationToken cancelToken = default);
+
+        Task<TagDropdownDetailsModel> UpdateDropdownTag(string externalToken, string tagId, TagDropdownModel tag, CancellationToken cancelToken = default);
+
+        Task<TagDropdownDetailsModel> DeleteDropdownTag(string externalToken, string tagId, CancellationToken cancelToken = default);
+
+        Task<List<CallbackSubscriptionModel>> GetCallbackSubscriptions(string externalToken, CancellationToken cancelToken = default);
+
+        Task<CallbackSubscriptionModel> GetCallbackSubscription(string externalToken, int callbackId, CancellationToken cancelToken = default);
+
+        Task AddCallbackSubscription(string externalToken, CallbackType callbackType, Uri callbackUri, CallbackStatus callbackStatus = CallbackStatus.Active, CancellationToken cancelToken = default);
+
+        Task UpdateCallbackSubscription(string externalToken, int callbackId, CallbackType callbackType, Uri callbackUri, CallbackStatus callbackStatus, CancellationToken cancelToken = default);
     }
 }

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -101,12 +101,12 @@ namespace PexCard.Api.Client
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Details/AllCardholderTransactionCount"));
 
-            var requestQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestQueryParams.Add("IncludePendings", includePendings.ToString());
-            requestQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestQueryParams.Add("EndDate", endDate.ToDateTimeString());
-            requestUriBuilder.Query = requestQueryParams.ToString();
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
+            requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
+            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
+            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
@@ -120,12 +120,12 @@ namespace PexCard.Api.Client
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Details/AllCardholderTransactions"));
 
-            var requestQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestQueryParams.Add("IncludePendings", includePendings.ToString());
-            requestQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestQueryParams.Add("EndDate", endDate.ToDateTimeString());
-            requestUriBuilder.Query = requestQueryParams.ToString();
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
+            requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
+            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
+            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
@@ -141,12 +141,12 @@ namespace PexCard.Api.Client
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Details/TransactionDetails"));
 
-            var requestQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestQueryParams.Add("IncludePendings", includePendings.ToString());
-            requestQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestQueryParams.Add("EndDate", endDate.ToDateTimeString());
-            requestUriBuilder.Query = requestQueryParams.ToString();
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
+            requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
+            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
+            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
@@ -297,12 +297,12 @@ namespace PexCard.Api.Client
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Details/TransactionDetails/{cardholderAccountId}"));
 
-            var requestQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestQueryParams.Add("IncludePendings", includePending.ToString());
-            requestQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestQueryParams.Add("StartDate", startDate.ToEst().ToDateTimeString());
-            requestQueryParams.Add("EndDate", endDate.ToEst().ToDateTimeString());
-            requestUriBuilder.Query = requestQueryParams.ToString();
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("IncludePendings", includePending.ToString());
+            requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
+            requestUriQueryParams.Add("StartDate", startDate.ToEst().ToDateTimeString());
+            requestUriQueryParams.Add("EndDate", endDate.ToEst().ToDateTimeString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -22,7 +22,8 @@ namespace PexCard.Api.Client
     public class PexApiClient : IPexApiClient
     {
         private const string PexCorrelationIdHeaderName = "X-CORRELATION-ID";
-        private const string JsonMediaType = "application/json";
+        private const string PexJsonMediaType = "application/json";
+        private readonly Encoding PexEncodingType = Encoding.UTF8;
 
         private readonly HttpClient _httpClient;
 
@@ -64,7 +65,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Bearer, jwt);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -197,7 +198,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -274,7 +275,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -363,7 +364,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -378,7 +379,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Put, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -424,7 +425,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -477,7 +478,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -492,7 +493,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Put, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -531,7 +532,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -546,7 +547,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Put, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -585,7 +586,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 
@@ -600,7 +601,7 @@ namespace PexCard.Api.Client
 
             var request = new HttpRequestMessage(HttpMethod.Put, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);
-            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), Encoding.UTF8, JsonMediaType);
+            request.Content = new StringContent(JsonConvert.SerializeObject(requestData), PexEncodingType, PexJsonMediaType);
 
             var response = await _httpClient.SendAsync(request, cancelToken);
 


### PR DESCRIPTION
[AB#58640](https://pexcard.visualstudio.com/1e893f43-a87f-46d1-abc4-e68d9e66c1ef/_workitems/edit/58640)
- cleanup `IPexApiClient` and `PexApiClient`
- make `PexApiClient` thread safe (http header access).