### PR TITLE
Fix GetBusinessSettings - Wrong Endpoint

### DIFF
--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -253,7 +253,7 @@ namespace PexCard.Api.Client
 
         public async Task<BusinessSettingsModel> GetBusinessSettings(string externalToken, CancellationToken cancelToken = default)
         {
-            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Details/Settings"));
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Business/Settings"));
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.Authorization = new AuthenticationHeaderValue(TokenType.Token, externalToken);


### PR DESCRIPTION
AB#59112

- Fix `GetBusinessSettings` which has incorrect resource URI after last update.