### PR TITLE
Add/Update Transaction Tags - Force Parameter (To Do Not Validate Required)

### DIFF
--- a/src/PexCard.Api.Client.Core/Extensions/IPexApiClientExtensions.cs
+++ b/src/PexCard.Api.Client.Core/Extensions/IPexApiClientExtensions.cs
@@ -47,7 +47,7 @@ namespace PexCard.Api.Client.Core.Extensions
                 tagDefinitions);
         }
 
-        public static async Task<Dictionary<long, List<AllocationTagValue>>> GetTagAllocations(
+        public static Task<Dictionary<long, List<AllocationTagValue>>> GetTagAllocations(
             this IPexApiClient pexApiClient,
             string externalToken,
             List<TransactionModel> transactions,
@@ -114,7 +114,7 @@ namespace PexCard.Api.Client.Core.Extensions
                 result.Add(transaction.TransactionId, allocations);
             }
 
-            return result;
+            return Task.FromResult(result);
         }
     }
 }

--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -49,9 +49,9 @@ namespace PexCard.Api.Client.Core
 
         Task<TagsModel> GetTransactionTags(string externalToken, long transactionId, CancellationToken cancelToken = default);
 
-        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default);
+        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default);
 
-        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default);
+        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default);
 
         Task<CardholderDetailsModel> GetCardholderDetails(string externalToken, int cardholderAccountId, CancellationToken cancelToken = default);
 

--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -49,9 +49,9 @@ namespace PexCard.Api.Client.Core
 
         Task<TagsModel> GetTransactionTags(string externalToken, long transactionId, CancellationToken cancelToken = default);
 
-        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default);
+        Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool? force = default, CancellationToken cancelToken = default);
 
-        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default);
+        Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool? force = default, CancellationToken cancelToken = default);
 
         Task<CardholderDetailsModel> GetCardholderDetails(string externalToken, int cardholderAccountId, CancellationToken cancelToken = default);
 

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -524,9 +525,13 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<TagsModel>(response);
         }
 
-        public async Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default)
+        public async Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Transactions/{transactionId}/Tags"));
+
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("force", force.ToString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var requestData = transactionTags;
 
@@ -539,9 +544,13 @@ namespace PexCard.Api.Client
             await HandleHttpResponseMessage(response);
         }
 
-        public async Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, CancellationToken cancelToken = default)
+        public async Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Transactions/{transactionId}/Tags"));
+
+            var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
+            requestUriQueryParams.Add("force", force.ToString());
+            requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var requestData = transactionTags;
 

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -525,12 +525,15 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<TagsModel>(response);
         }
 
-        public async Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default)
+        public async Task AddTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool? force = default, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Transactions/{transactionId}/Tags"));
 
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestUriQueryParams.Add("force", force.ToString());
+            if (force.HasValue)
+            {
+                requestUriQueryParams.Add("force", force.ToString());
+            }
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var requestData = transactionTags;
@@ -544,12 +547,15 @@ namespace PexCard.Api.Client
             await HandleHttpResponseMessage(response);
         }
 
-        public async Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool force = false, CancellationToken cancelToken = default)
+        public async Task UpdateTransactionTags(string externalToken, long transactionId, UpsertTransactionTagsModel transactionTags, bool? force = default, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Transactions/{transactionId}/Tags"));
 
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
-            requestUriQueryParams.Add("force", force.ToString());
+            if (force.HasValue)
+            {
+                requestUriQueryParams.Add("force", force.ToString());
+            }
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var requestData = transactionTags;


### PR DESCRIPTION
Add optional force parameter to Add/Update transaction tag client methods that will skip validation of all required tags being populated.