### PR TITLE
ISO8601 DateTime Formats

### DIFF
--- a/src/PexCard.Api.Client/Extensions/DateTimeExtension.cs
+++ b/src/PexCard.Api.Client/Extensions/DateTimeExtension.cs
@@ -2,7 +2,7 @@
 {
     internal static class DateTimeExtension
     {
-        public static string ToStringIso8601(this DateTime dateTime)
+        public static string ToStringISO8601(this DateTime dateTime)
         {
             return dateTime.ToString("o");
         }

--- a/src/PexCard.Api.Client/Extensions/DateTimeExtension.cs
+++ b/src/PexCard.Api.Client/Extensions/DateTimeExtension.cs
@@ -1,23 +1,10 @@
-﻿using System;
-using PexCard.Api.Client.Const;
-
-namespace PexCard.Api.Client.Extensions
+﻿namespace System
 {
     internal static class DateTimeExtension
     {
-        public static DateTime ToTimeZone(this DateTime _this, TimeZoneInfo tz)
+        public static string ToStringIso8601(this DateTime dateTime)
         {
-            return TimeZoneInfo.ConvertTime(_this, tz);
-        }
-
-        public static DateTime ToEst(this DateTime _this)
-        {
-            return _this.ToTimeZone(TimeZoneConst.Est);
-        }
-
-        public static string ToDateTimeString(this DateTime _this)
-        {
-            return _this.ToString("yyyy-MM-ddTHH:mm:ss");
+            return dateTime.ToString("o");
         }
     }
 }

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -104,8 +104,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -124,8 +124,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -146,8 +146,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToDateTimeString());
-            requestUriQueryParams.Add("EndDate", endDate.ToDateTimeString());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -311,8 +311,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePending.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToEst().ToDateTimeString());
-            requestUriQueryParams.Add("EndDate", endDate.ToEst().ToDateTimeString());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -671,9 +671,9 @@ namespace PexCard.Api.Client
             await HandleHttpResponseMessage(response);
         }
 
-        public async Task<List<InvoiceModel>> GetInvoices(string externalToken, DateTime starDate, CancellationToken cancelToken = default)
+        public async Task<List<InvoiceModel>> GetInvoices(string externalToken, DateTime startDate, CancellationToken cancelToken = default)
         {
-            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Invoices?startDate={starDate}"));
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Invoices?startDate={startDate.ToStringIso8601()}"));
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.SetPexCorrelationIdHeader();

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -104,8 +104,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
-            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringISO8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringISO8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -124,8 +124,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
-            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringISO8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringISO8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -146,8 +146,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
-            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringISO8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringISO8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -311,8 +311,8 @@ namespace PexCard.Api.Client
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePending.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
-            requestUriQueryParams.Add("StartDate", startDate.ToStringIso8601());
-            requestUriQueryParams.Add("EndDate", endDate.ToStringIso8601());
+            requestUriQueryParams.Add("StartDate", startDate.ToStringISO8601());
+            requestUriQueryParams.Add("EndDate", endDate.ToStringISO8601());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
@@ -673,7 +673,7 @@ namespace PexCard.Api.Client
 
         public async Task<List<InvoiceModel>> GetInvoices(string externalToken, DateTime startDate, CancellationToken cancelToken = default)
         {
-            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Invoices?startDate={startDate.ToStringIso8601()}"));
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Invoices?startDate={startDate.ToStringISO8601()}"));
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
             request.Headers.SetPexCorrelationIdHeader();


### PR DESCRIPTION
- don't convert to EST
- use ISO8601 format of date times to API