### PR TITLE
Automate Github Releases

### DIFF
--- a/build/azure-pipelines-debug.yml
+++ b/build/azure-pipelines-debug.yml
@@ -2,8 +2,6 @@ trigger: none
 pr:
  - master
 
-name: $[format('{0}_{1}', variables['Build.SourceBranchName'], variables['versionNumber'])]
-
 pool:
   vmImage: 'ubuntu-latest'
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 pr: none
 
-name: $[format('{0}_{1}', variables['Build.SourceBranchName'], variables['versionPrefix'])]
+name: $(versionPrefix)
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
- needed to automate creating github releases with release notes on publish release to NuGet.
- updating build names so we can use the publish-build name (i.e. the versionPrefix, ex: "1.42.0") as the tag and release name.