### PR TITLE
Improve PEX Client Configuration of Retry Policies

### DIFF
--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/BackoffRetryPolicy.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/BackoffRetryPolicy.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public record BackoffRetryPolicy
+    public record struct BackoffRetryPolicy
     {
-        public static readonly BackoffRetryPolicy None = new BackoffRetryPolicy(TimeSpan.MinValue, 0);
+        public static BackoffRetryPolicy None => new BackoffRetryPolicy(TimeSpan.MinValue, 0);
 
         public BackoffRetryPolicy()
         {

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/BackoffRetryPolicy.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/BackoffRetryPolicy.cs
@@ -4,10 +4,18 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public class BackoffRetryPolicy
+    public record BackoffRetryPolicy
     {
+        public static readonly BackoffRetryPolicy None = new BackoffRetryPolicy(TimeSpan.MinValue, 0);
+
         public BackoffRetryPolicy()
         {
+        }
+
+        public BackoffRetryPolicy(BackoffRetryPolicy other)
+        {
+            Delay = other.Delay;
+            Retries = other.Retries;
         }
 
         public BackoffRetryPolicy(TimeSpan delay, int retries)
@@ -17,8 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [JsonConverter(typeof(JsonTimeSpanConverter))]
-        public TimeSpan Delay { get; set; } = TimeSpan.FromMilliseconds(100);
+        public TimeSpan Delay { get; set; } = TimeSpan.MinValue;
 
-        public int Retries { get; set; } = 1;
+        public int Retries { get; set; } = 0;
     }
 }

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static PexRetryPolicyOptions None => new PexRetryPolicyOptions
         {
-            RetryLogLevel = LogLevel.Warning,
+            RetryLogLevel = LogLevel.None,
             TooManyRequests = BackoffRetryPolicy.None,
             Timeouts = BackoffRetryPolicy.None,
             ServerErrors = BackoffRetryPolicy.None,

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
@@ -3,14 +3,30 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public class PexRetryPolicyOptions
+    public record PexRetryPolicyOptions
     {
+        public static readonly PexRetryPolicyOptions None = new PexRetryPolicyOptions
+        {
+            RetryLogLevel = LogLevel.Warning,
+            TooManyRequests = BackoffRetryPolicy.None,
+            Timeouts = BackoffRetryPolicy.None,
+            ServerErrors = BackoffRetryPolicy.None,
+        };
+
+        public static readonly PexRetryPolicyOptions Default = new PexRetryPolicyOptions
+        {
+            RetryLogLevel = LogLevel.Warning,
+            TooManyRequests = new BackoffRetryPolicy(TimeSpan.FromSeconds(5), 7),
+            Timeouts = new BackoffRetryPolicy(TimeSpan.FromSeconds(1), 2),
+            ServerErrors = new BackoffRetryPolicy(TimeSpan.FromMilliseconds(100), 1),
+        };
+
         public LogLevel RetryLogLevel { get; set; } = LogLevel.Warning;
 
-        public BackoffRetryPolicy TooManyRequests { get; set; } = new BackoffRetryPolicy(TimeSpan.FromSeconds(5), 7);
+        public BackoffRetryPolicy TooManyRequests { get; set; } = new BackoffRetryPolicy();
 
-        public BackoffRetryPolicy Timeouts { get; set; } = new BackoffRetryPolicy(TimeSpan.FromSeconds(1), 2);
+        public BackoffRetryPolicy Timeouts { get; set; } = new BackoffRetryPolicy();
 
-        public BackoffRetryPolicy ServerErrors { get; set; } = new BackoffRetryPolicy(TimeSpan.FromMilliseconds(100), 1);
+        public BackoffRetryPolicy ServerErrors { get; set; } = new BackoffRetryPolicy();
     }
 }

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public record PexRetryPolicyOptions
     {
-        public static readonly PexRetryPolicyOptions None = new PexRetryPolicyOptions
+        public static PexRetryPolicyOptions None => new PexRetryPolicyOptions
         {
             RetryLogLevel = LogLevel.Warning,
             TooManyRequests = BackoffRetryPolicy.None,
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ServerErrors = BackoffRetryPolicy.None,
         };
 
-        public static readonly PexRetryPolicyOptions Default = new PexRetryPolicyOptions
+        public static PexRetryPolicyOptions Default => new PexRetryPolicyOptions
         {
             RetryLogLevel = LogLevel.Warning,
             TooManyRequests = new BackoffRetryPolicy(TimeSpan.FromSeconds(5), 7),

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static PexRetryPolicyOptions None => new PexRetryPolicyOptions
         {
-            RetryLogLevel = LogLevel.None,
+            RetryLogLevel = LogLevel.Warning,
             TooManyRequests = BackoffRetryPolicy.None,
             Timeouts = BackoffRetryPolicy.None,
             ServerErrors = BackoffRetryPolicy.None,

--- a/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
+++ b/src/PexCard.Api.Client/Configure/HttpClient/Retries/PexRetryPolicyOptions.cs
@@ -7,26 +7,18 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static PexRetryPolicyOptions None => new PexRetryPolicyOptions
         {
-            RetryLogLevel = LogLevel.Warning,
+            RetryLogLevel = LogLevel.None,
             TooManyRequests = BackoffRetryPolicy.None,
             Timeouts = BackoffRetryPolicy.None,
             ServerErrors = BackoffRetryPolicy.None,
         };
 
-        public static PexRetryPolicyOptions Default => new PexRetryPolicyOptions
-        {
-            RetryLogLevel = LogLevel.Warning,
-            TooManyRequests = new BackoffRetryPolicy(TimeSpan.FromSeconds(5), 7),
-            Timeouts = new BackoffRetryPolicy(TimeSpan.FromSeconds(1), 2),
-            ServerErrors = new BackoffRetryPolicy(TimeSpan.FromMilliseconds(100), 1),
-        };
-
         public LogLevel RetryLogLevel { get; set; } = LogLevel.Warning;
 
-        public BackoffRetryPolicy TooManyRequests { get; set; } = new BackoffRetryPolicy();
+        public BackoffRetryPolicy TooManyRequests { get; set; } = new BackoffRetryPolicy(TimeSpan.FromSeconds(5), 7);
 
-        public BackoffRetryPolicy Timeouts { get; set; } = new BackoffRetryPolicy();
+        public BackoffRetryPolicy Timeouts { get; set; } = new BackoffRetryPolicy(TimeSpan.FromSeconds(1), 2);
 
-        public BackoffRetryPolicy ServerErrors { get; set; } = new BackoffRetryPolicy();
+        public BackoffRetryPolicy ServerErrors { get; set; } = new BackoffRetryPolicy(TimeSpan.FromMilliseconds(100), 1);
     }
 }

--- a/src/PexCard.Api.Client/Configure/PexApiClientOptions.cs
+++ b/src/PexCard.Api.Client/Configure/PexApiClientOptions.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace PexCard.Api.Client
 {
-    public class PexApiClientOptions
+    public record PexApiClientOptions
     {
         public string AppName { get; set; }
 
@@ -23,6 +23,6 @@ namespace PexCard.Api.Client
 
         public LogLevel LogLevelFailure { get; set; } = LogLevel.Warning;
 
-        public PexRetryPolicyOptions Retries { get; set; } = new PexRetryPolicyOptions();
+        public PexRetryPolicyOptions Retries { get; set; } = PexRetryPolicyOptions.Default;
     }
 }

--- a/src/PexCard.Api.Client/Configure/PexAuthClientOptions.cs
+++ b/src/PexCard.Api.Client/Configure/PexAuthClientOptions.cs
@@ -23,6 +23,6 @@ namespace PexCard.Api.Client
 
         public LogLevel LogLevelFailure { get; set; } = LogLevel.Warning;
 
-        public PexRetryPolicyOptions Retries { get; set; } = new PexRetryPolicyOptions();
+        public PexRetryPolicyOptions Retries { get; set; } = PexRetryPolicyOptions.Default;
     }
 }

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using PexCard.Api.Client.Const;
 using PexCard.Api.Client.Core;
 using PexCard.Api.Client.Core.Enums;
@@ -483,6 +484,7 @@ namespace PexCard.Api.Client
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
+            request.DontRetryRequest();
             request.Headers.SetPexCorrelationIdHeader();
             request.Headers.SetPexAcceptJsonHeader();
             request.Headers.SetPexAuthorizationHeader(externalToken);


### PR DESCRIPTION
[AB#99270](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/99270)

- add 'none' retry policies
- add ability to prevent request retry in http client for specific requests
- prevent retries for FundCard requests