### PR TITLE
AB#137848 pex-sdk-dotnet: Add UserGroup support and deprecate cardhol…

### DIFF
--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -79,15 +79,60 @@ namespace PexCard.Api.Client.Core
 
         Task UpdateCardholderCardStatus(string externalToken, int cardholderAccountId, CardStatus status, CancellationToken cancelToken = default);
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(GetUserGroups) + " (/UserGroup) instead.")]
         Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken cancelToken = default);
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(GetUserGroup) + " (/UserGroup) instead.")]
         Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default);
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(CreateUserGroup) + " (/UserGroup) instead.")]
         Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken cancelToken = default);
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(UpdateUserGroup) + " (/UserGroup) instead.")]
         Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken cancelToken = default);
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(DeleteUserGroup) + " (/UserGroup) instead.")]
         Task DeleteCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Return the list of User Groups for the business.
+        /// </summary>
+        Task<List<UserGroupBrief>> GetUserGroups(string externalToken, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Return a single User Group.
+        /// </summary>
+        Task<UserGroupBrief> GetUserGroup(string externalToken, long userGroupId, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Create a User Group.
+        /// </summary>
+        Task<UserGroupBrief> CreateUserGroup(string externalToken, string name, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Update the User Group name.
+        /// </summary>
+        Task<UserGroupBrief> UpdateUserGroup(string externalToken, long userGroupId, string name, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Delete a User Group. Cardholders that were members are no longer associated with it.
+        /// </summary>
+        Task DeleteUserGroup(string externalToken, long userGroupId, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Return all cardholders in a User Group.
+        /// </summary>
+        Task<List<UserGroupCardholder>> GetUserGroupCardholders(string externalToken, long userGroupId, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Add a cardholder (by account id) to a User Group. A cardholder may belong to multiple User Groups.
+        /// </summary>
+        Task AddCardholderToUserGroup(string externalToken, long userGroupId, int accountId, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Remove a cardholder (by account id) from a User Group.
+        /// </summary>
+        Task RemoveCardholderFromUserGroup(string externalToken, long userGroupId, int accountId, CancellationToken cancelToken = default);
 
         Task<int> CreateCardOrder(string externalToken, CardOrderModel cardOrder, CancellationToken cancelToken = default);
 

--- a/src/PexCard.Api.Client.Core/Models/BusinessDetailsModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BusinessDetailsModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace PexCard.Api.Client.Core.Models
 {
@@ -22,7 +23,16 @@ namespace PexCard.Api.Client.Core.Models
 
         public int OpenVendorCardsCount { get; set; }
 
+        /// <summary>
+        /// Legacy cardholder groups for the business.
+        /// </summary>
+        [Obsolete("Legacy single-group collection. Use " + nameof(UserGroups) + " and the /UserGroup endpoints instead.")]
         public List<GroupModel> CardholderGroups { get; set; }
+
+        /// <summary>
+        /// User Groups defined for the business.
+        /// </summary>
+        public List<UserGroupBrief> UserGroups { get; set; }
 
         public List<ExternalBankAccount> BankAccountList { get; set; }
     }

--- a/src/PexCard.Api.Client.Core/Models/CardOrderLineModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardOrderLineModel.cs
@@ -18,8 +18,15 @@ namespace PexCard.Api.Client.Core.Models
         /// <summary>Cardholder email address</summary>
         public string Email { get; set; }
 
-        /// <summary> Cardholder group id </summary>
+        /// <summary> Legacy cardholder group id </summary>
         public int? GroupId { get; set; }
+
+        /// <summary>
+        /// Id of the User Group to assign the new card to. Honored only when the business has the
+        /// cardholder-group feature enabled; otherwise it is nulled out server-side. When both
+        /// <see cref="GroupId"/> and <see cref="UserGroupId"/> are supplied they must reference the same group.
+        /// </summary>
+        public long? UserGroupId { get; set; }
 
         /// <summary> Cardhodler ruleset id </summary>
         public int? RulesetId { get; set; }

--- a/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderAccountModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace PexCard.Api.Client.Core.Models
 {
@@ -58,14 +59,26 @@ namespace PexCard.Api.Client.Core.Models
         public string CustomId { get; set; }
 
         /// <summary>
-        /// Cardholder's group id.
+        /// Cardholder's legacy group id.
         /// </summary>
+        [Obsolete("Legacy single-group field. Use " + nameof(UserGroupId) + " / " + nameof(UserGroups) + " and the /UserGroup endpoints instead.")]
         public int? GroupId { get; set; }
 
         /// <summary>
-        /// Cardholder's group name.
+        /// Cardholder's legacy group name.
         /// </summary>
+        [Obsolete("Legacy single-group field. Use " + nameof(UserGroups) + " and the /UserGroup endpoints instead.")]
         public string GroupName { get; set; }
+
+        /// <summary>
+        /// Id of the User Group the cardholder belongs to, when applicable; otherwise null.
+        /// </summary>
+        public long? UserGroupId { get; set; }
+
+        /// <summary>
+        /// User Groups the cardholder belongs to.
+        /// </summary>
+        public List<UserGroupBrief> UserGroups { get; set; }
 
         /// <summary>
         /// Cardholder's active card status (NULL, Active, Inactive, Closed, Blocked).

--- a/src/PexCard.Api.Client.Core/Models/CardholderDetailsModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderDetailsModel.cs
@@ -17,7 +17,18 @@ namespace PexCard.Api.Client.Core.Models
         public string Email { get; set; }
         public bool IsVirtual { get; set; }
         public string CustomId { get; set; }
+
+        /// <summary>
+        /// Legacy single cardholder group.
+        /// </summary>
+        [Obsolete("Legacy single-group field. Use " + nameof(UserGroups) + " and the /UserGroup endpoints instead.")]
         public CardholderGroupModel Group { get; set; }
+
+        /// <summary>
+        /// User Groups the cardholder belongs to.
+        /// </summary>
+        public List<UserGroupBrief> UserGroups { get; set; }
+
         public List<CardDetailModel> CardList { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/CardholderGroupModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderGroupModel.cs
@@ -4,5 +4,10 @@
     {
         public int Id { get; set; }
         public string GroupName { get; set; }
+
+        /// <summary>
+        /// Id of the User Group this legacy group corresponds to, when applicable; otherwise null.
+        /// </summary>
+        public long? UserGroupId { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/CardholderProfileModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CardholderProfileModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 namespace PexCard.Api.Client.Core.Models
 {
     public class CardholderProfileModel
@@ -9,7 +10,23 @@ namespace PexCard.Api.Client.Core.Models
         public string FirstName { get; set; }
         public string MiddleName { get; set; }
         public string LastName { get; set; }
+
+        /// <summary>
+        /// Legacy single cardholder group id.
+        /// </summary>
+        [Obsolete("Legacy single-group field. Use " + nameof(UserGroupId) + " / " + nameof(UserGroups) + " and the /UserGroup endpoints instead.")]
         public int CardholderGroupId { get; set; }
+
+        /// <summary>
+        /// Id of the User Group the cardholder belongs to, when applicable; otherwise null.
+        /// </summary>
+        public long? UserGroupId { get; set; }
+
+        /// <summary>
+        /// User Groups the cardholder belongs to.
+        /// </summary>
+        public List<UserGroupBrief> UserGroups { get; set; }
+
         public int SpendRulesetId { get; set; }
         public AddressContactModel ProfileAddress { get; set; }
         public string Phone { get; set; }

--- a/src/PexCard.Api.Client.Core/Models/GroupModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/GroupModel.cs
@@ -5,5 +5,10 @@
         public int Id { get; set; }
 
         public string Name { get; set; }
+
+        /// <summary>
+        /// Id of the User Group this legacy group corresponds to, when applicable; otherwise null.
+        /// </summary>
+        public long? UserGroupId { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/UserGroupBrief.cs
+++ b/src/PexCard.Api.Client.Core/Models/UserGroupBrief.cs
@@ -1,0 +1,30 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Summary of a User Group. User Groups are the forward-looking, many-to-many
+    /// replacement for the legacy 1:1 cardholder Group model.
+    /// </summary>
+    public class UserGroupBrief
+    {
+        /// <summary>
+        /// Unique id of the User Group.
+        /// </summary>
+        public long UserGroupId { get; set; }
+
+        /// <summary>
+        /// User Group name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Type of the group. Kept as a string to mirror the External API contract (which serializes
+        /// the group-type enum by name) and to stay forward-compatible if new group types are added.
+        /// </summary>
+        public string GroupType { get; set; }
+
+        /// <summary>
+        /// Legacy group id this User Group corresponds to, when applicable; otherwise null.
+        /// </summary>
+        public int? LegacyGroupId { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/UserGroupCardholder.cs
+++ b/src/PexCard.Api.Client.Core/Models/UserGroupCardholder.cs
@@ -1,0 +1,28 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// A cardholder member of a User Group, identified by cardholder account id.
+    /// </summary>
+    public class UserGroupCardholder
+    {
+        /// <summary>
+        /// Account id of the member.
+        /// </summary>
+        public int AccountId { get; set; }
+
+        /// <summary>
+        /// Member first name.
+        /// </summary>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Member last name.
+        /// </summary>
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Member user name (login/email).
+        /// </summary>
+        public string UserName { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/VendorCardOrderItemRequest.cs
+++ b/src/PexCard.Api.Client.Core/Models/VendorCardOrderItemRequest.cs
@@ -6,6 +6,13 @@
         public string Phone { get; set; }
         public string Email { get; set; }
         public int? GroupId { get; set; }
+
+        /// <summary>
+        /// Id of the User Group to assign the new vendor card to. Honored only when the business has the
+        /// cardholder-group feature enabled; otherwise it is nulled out server-side. When both
+        /// <see cref="GroupId"/> and <see cref="UserGroupId"/> are supplied they must reference the same group.
+        /// </summary>
+        public long? UserGroupId { get; set; }
         public int? RulesetId { get; set; }
         public bool AutoActivation { get; set; } = true;
         public FundingType FundingType { get; set; }

--- a/src/PexCard.Api.Client.Core/Models/VendorCardOrderItemResponse.cs
+++ b/src/PexCard.Api.Client.Core/Models/VendorCardOrderItemResponse.cs
@@ -13,6 +13,11 @@ namespace PexCard.Api.Client.Core.Models
         public string Email { get; set; }
         public AddressModel HomeAddress { get; set; }
         public int? GroupId { get; set; }
+
+        /// <summary>
+        /// Id of the User Group the vendor card was assigned to, when applicable; otherwise null.
+        /// </summary>
+        public long? UserGroupId { get; set; }
         public int? SpendingRulesetsId { get; set; }
         public bool AutoActivation { get; set; }
         public decimal? FundCardAmount { get; set; }

--- a/src/PexCard.Api.Client/Models/CreateUserGroupRequest.cs
+++ b/src/PexCard.Api.Client/Models/CreateUserGroupRequest.cs
@@ -1,0 +1,13 @@
+namespace PexCard.Api.Client.Models
+{
+    /// <summary>
+    /// Details required to create a User Group.
+    /// </summary>
+    public class CreateUserGroupRequest
+    {
+        /// <summary>
+        /// User Group name (maximum 50 characters).
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client/Models/UpdateUserGroupRequest.cs
+++ b/src/PexCard.Api.Client/Models/UpdateUserGroupRequest.cs
@@ -1,0 +1,13 @@
+namespace PexCard.Api.Client.Models
+{
+    /// <summary>
+    /// Details required to update a User Group.
+    /// </summary>
+    public class UpdateUserGroupRequest
+    {
+        /// <summary>
+        /// User Group name (maximum 50 characters).
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -795,6 +795,7 @@ namespace PexCard.Api.Client
             return responseData.CardOrderId;
         }
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(GetUserGroups) + " (/UserGroup) instead.")]
         public async Task<CardholderGroupsResponseModel> GetCardholderGroups(string externalToken, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Group"));
@@ -809,6 +810,7 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<CardholderGroupsResponseModel>(response);
         }
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(GetUserGroup) + " (/UserGroup) instead.")]
         public async Task<CardholderGroupResponseModel> GetCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Group/{groupId}"));
@@ -823,6 +825,7 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
         }
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(CreateUserGroup) + " (/UserGroup) instead.")]
         public async Task<CardholderGroupResponseModel> CreateCardholderGroup(string externalToken, string groupName, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Group"));
@@ -840,6 +843,7 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
         }
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(UpdateUserGroup) + " (/UserGroup) instead.")]
         public async Task<CardholderGroupResponseModel> UpdateCardholderGroupName(string externalToken, int groupId, string groupName, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Group/{groupId}"));
@@ -857,9 +861,125 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<CardholderGroupResponseModel>(response);
         }
 
+        [Obsolete("Legacy cardholder Group endpoint. Use " + nameof(DeleteUserGroup) + " (/UserGroup) instead.")]
         public async Task DeleteCardholderGroup(string externalToken, int groupId, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Group/{groupId}"));
+
+            var request = new HttpRequestMessage(HttpMethod.Delete, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            await HandleHttpResponseMessage(response);
+        }
+
+        public async Task<List<UserGroupBrief>> GetUserGroups(string externalToken, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/UserGroup"));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<List<UserGroupBrief>>(response);
+        }
+
+        public async Task<UserGroupBrief> GetUserGroup(string externalToken, long userGroupId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}"));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<UserGroupBrief>(response);
+        }
+
+        public async Task<UserGroupBrief> CreateUserGroup(string externalToken, string name, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/UserGroup"));
+
+            var requestData = new CreateUserGroupRequest { Name = name };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+            request.SetPexJsonContent(requestData);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<UserGroupBrief>(response);
+        }
+
+        public async Task<UserGroupBrief> UpdateUserGroup(string externalToken, long userGroupId, string name, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}"));
+
+            var requestData = new UpdateUserGroupRequest { Name = name };
+
+            var request = new HttpRequestMessage(HttpMethod.Put, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+            request.SetPexJsonContent(requestData);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<UserGroupBrief>(response);
+        }
+
+        public async Task DeleteUserGroup(string externalToken, long userGroupId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}"));
+
+            var request = new HttpRequestMessage(HttpMethod.Delete, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            await HandleHttpResponseMessage(response);
+        }
+
+        public async Task<List<UserGroupCardholder>> GetUserGroupCardholders(string externalToken, long userGroupId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}/cardholders"));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<List<UserGroupCardholder>>(response);
+        }
+
+        public async Task AddCardholderToUserGroup(string externalToken, long userGroupId, int accountId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}/cardholders/{accountId}"));
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            await HandleHttpResponseMessage(response);
+        }
+
+        public async Task RemoveCardholderFromUserGroup(string externalToken, long userGroupId, int accountId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/UserGroup/{userGroupId}/cardholders/{accountId}"));
 
             var request = new HttpRequestMessage(HttpMethod.Delete, requestUriBuilder.Uri);
             request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/UserGroupSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/UserGroupSerializationTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using PexCard.Api.Client.Core.Models;
+using Xunit;
+
+namespace PexCard.Api.Client.Core.Tests.Serialization
+{
+    public class UserGroupSerializationTests
+    {
+        [Fact]
+        public void UserGroupBrief_DeserializesFromServer()
+        {
+            const string json = @"{
+                ""UserGroupId"": 1234567890123,
+                ""Name"": ""Finance"",
+                ""GroupType"": ""CardholderGroup"",
+                ""LegacyGroupId"": 42
+            }";
+
+            var model = JsonConvert.DeserializeObject<UserGroupBrief>(json);
+
+            Assert.Equal(1234567890123L, model.UserGroupId);
+            Assert.Equal("Finance", model.Name);
+            Assert.Equal("CardholderGroup", model.GroupType);
+            Assert.Equal(42, model.LegacyGroupId);
+        }
+
+        [Fact]
+        public void UserGroupBrief_AllowsNullLegacyGroupId()
+        {
+            const string json = @"{
+                ""UserGroupId"": 7,
+                ""Name"": ""Ops"",
+                ""GroupType"": ""CardholderGroup"",
+                ""LegacyGroupId"": null
+            }";
+
+            var model = JsonConvert.DeserializeObject<UserGroupBrief>(json);
+
+            Assert.Null(model.LegacyGroupId);
+        }
+
+        [Fact]
+        public void UserGroupCardholder_DeserializesFromServer()
+        {
+            const string json = @"{
+                ""AccountId"": 555,
+                ""FirstName"": ""Ada"",
+                ""LastName"": ""Lovelace"",
+                ""UserName"": ""ada@example.com""
+            }";
+
+            var model = JsonConvert.DeserializeObject<UserGroupCardholder>(json);
+
+            Assert.Equal(555, model.AccountId);
+            Assert.Equal("Ada", model.FirstName);
+            Assert.Equal("Lovelace", model.LastName);
+            Assert.Equal("ada@example.com", model.UserName);
+        }
+
+        [Fact]
+        public void CardholderProfile_CarriesUserGroupAlongsideLegacyGroup()
+        {
+            const string json = @"{
+                ""AccountId"": 10,
+                ""CardholderGroupId"": 42,
+                ""UserGroupId"": 1234567890123,
+                ""UserGroups"": [
+                    { ""UserGroupId"": 1234567890123, ""Name"": ""Finance"", ""GroupType"": ""CardholderGroup"", ""LegacyGroupId"": 42 }
+                ]
+            }";
+
+            var model = JsonConvert.DeserializeObject<CardholderProfileModel>(json);
+
+#pragma warning disable CS0618 // legacy field intentionally exercised
+            Assert.Equal(42, model.CardholderGroupId);
+#pragma warning restore CS0618
+            Assert.Equal(1234567890123L, model.UserGroupId);
+            Assert.Single(model.UserGroups);
+            Assert.Equal("Finance", model.UserGroups[0].Name);
+        }
+
+        [Fact]
+        public void CreateUserGroupRequest_SerializesNameAsPascalCase()
+        {
+            var json = JsonConvert.SerializeObject(new PexCard.Api.Client.Models.CreateUserGroupRequest { Name = "Finance" });
+
+            Assert.Equal(@"{""Name"":""Finance""}", json);
+        }
+
+        [Fact]
+        public void BusinessDetails_CarriesUserGroupsList()
+        {
+            const string json = @"{
+                ""BusinessAccountId"": 1,
+                ""UserGroups"": [
+                    { ""UserGroupId"": 9, ""Name"": ""Travel"", ""GroupType"": ""CardholderGroup"", ""LegacyGroupId"": null }
+                ]
+            }";
+
+            var model = JsonConvert.DeserializeObject<BusinessDetailsModel>(json);
+
+            Assert.NotNull(model.UserGroups);
+            Assert.Single(model.UserGroups);
+            Assert.Equal(9, model.UserGroups[0].UserGroupId);
+        }
+    }
+}


### PR DESCRIPTION
# [AB#137848](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/137848) pex-sdk-dotnet: Add UserGroup support and deprecate cardholder Group members

## Summary

Updates the SDK to match the External API **cardholder Groups → User Groups** migration. Existing models gain the new User Group fields alongside (not replacing) the legacy single-Group fields, and the SDK adds full client coverage for the new `/UserGroup` controller. Legacy single-Group surfaces are marked `[Obsolete]` but remain functional — no breaking removals in this change.

Implements work item **[AB#137848](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/137848)**. Mirrors External API PRs `!64739`, `!64969`, `!65017`, `!66338`, `!66467`.

## Changes

### New models
- `UserGroupBrief` — `long UserGroupId`, `string Name`, `string GroupType`, `int? LegacyGroupId`
- `UserGroupCardholder` — `int AccountId`, `string FirstName`, `string LastName`, `string UserName`
- `CreateUserGroupRequest` / `UpdateUserGroupRequest` — `{ string Name }`

### Extended existing models
Added `long? UserGroupId` alongside the existing legacy `GroupId`/`CardholderGroupId`:
- `CardholderProfileModel`, `CardholderAccountModel`, `CardholderGroupModel`, `GroupModel`, `CardOrderLineModel`, `VendorCardOrderItemRequest`, `VendorCardOrderItemResponse`

Added `List<UserGroupBrief> UserGroups`:
- `CardholderProfileModel`, `CardholderDetailsModel`, `BusinessDetailsModel`, `CardholderAccountModel`

> Note: on input, `UserGroupId` is honored only when the business has the cardholder-group feature enabled; otherwise the External API nulls it out server-side. When both `GroupId` and `UserGroupId` are supplied they must reference the same group.

### New `/UserGroup` client surface
Added 8 methods to `IPexApiClient` / `PexApiClient` (all under `V4/UserGroup`, identifiers are cardholder account ids):

| Verb | Route | Method |
|---|---|---|
| GET | `/UserGroup` | `GetUserGroups` |
| POST | `/UserGroup` | `CreateUserGroup` |
| GET | `/UserGroup/{id}` | `GetUserGroup` |
| PUT | `/UserGroup/{id}` | `UpdateUserGroup` |
| DELETE | `/UserGroup/{id}` | `DeleteUserGroup` |
| GET | `/UserGroup/{id}/cardholders` | `GetUserGroupCardholders` |
| POST | `/UserGroup/{id}/cardholders/{accountId}` | `AddCardholderToUserGroup` |
| DELETE | `/UserGroup/{id}/cardholders/{accountId}` | `RemoveCardholderFromUserGroup` |

### Deprecation
- Legacy `/Group` client methods (`GetCardholderGroups`, `GetCardholderGroup`, `CreateCardholderGroup`, `UpdateCardholderGroupName`, `DeleteCardholderGroup`) marked `[Obsolete]`, pointing to the `/UserGroup` equivalents.
- Legacy single-group fields (`CardholderGroupId`, `GroupId`/`GroupName`, `CardholderDetailsModel.Group`, `BusinessDetailsModel.CardholderGroups`) marked `[Obsolete]`, pointing to `UserGroupId` / `UserGroups`.
- All deprecated members remain fully functional.

## Migration guide (for SDK consumers)

The legacy `/Group` methods and single-Group fields still work, but are now `[Obsolete]`. New code should use the User Group equivalents. Key differences: User Group ids are `long` (not `int`), group membership is **many-to-many** (a cardholder can belong to multiple User Groups), and responses return `UserGroupBrief` directly rather than wrapper response models.

### Listing groups

```csharp
// Before
CardholderGroupsResponseModel resp = await client.GetCardholderGroups(token);
foreach (GroupModel g in resp.Groups) { /* g.Id (int), g.Name */ }

// After
List<UserGroupBrief> groups = await client.GetUserGroups(token);
foreach (UserGroupBrief g in groups) { /* g.UserGroupId (long), g.Name, g.GroupType, g.LegacyGroupId */ }
```

### Get / create / update / delete

```csharp
// Before
CardholderGroupResponseModel one    = await client.GetCardholderGroup(token, groupId);
CardholderGroupResponseModel made   = await client.CreateCardholderGroup(token, "Finance");
CardholderGroupResponseModel edited = await client.UpdateCardholderGroupName(token, groupId, "Finance Team");
await client.DeleteCardholderGroup(token, groupId);

// After
UserGroupBrief one    = await client.GetUserGroup(token, userGroupId);
UserGroupBrief made   = await client.CreateUserGroup(token, "Finance");
UserGroupBrief edited = await client.UpdateUserGroup(token, userGroupId, "Finance Team");
await client.DeleteUserGroup(token, userGroupId);
```

### Managing membership (new capability)

There was no legacy equivalent — cardholder→group was a single field set elsewhere. User Groups support explicit, many-to-many membership:

```csharp
List<UserGroupCardholder> members = await client.GetUserGroupCardholders(token, userGroupId);

await client.AddCardholderToUserGroup(token, userGroupId, accountId);
await client.RemoveCardholderFromUserGroup(token, userGroupId, accountId);
```

### Reading a cardholder's group on models

```csharp
// Before — single legacy group
CardholderProfileModel profile = await client.GetCardholderProfile(token, accountId);
int legacyGroupId = profile.CardholderGroupId;          // [Obsolete]

CardholderDetailsModel details = await client.GetCardholderDetails(token, accountId);
CardholderGroupModel group = details.Group;             // [Obsolete]

// After — User Group id + the full membership list
long? userGroupId = profile.UserGroupId;
List<UserGroupBrief> profileGroups = profile.UserGroups;
List<UserGroupBrief> detailGroups  = details.UserGroups;
```

### Assigning a group on card / vendor-card creation

```csharp
// Before — legacy int GroupId
var line = new CardOrderLineModel { /* ... */ GroupId = 42 };
var vendor = new VendorCardOrderItemRequest { /* ... */ GroupId = 42 };

// After — long? UserGroupId (set alongside or instead of GroupId).
// If both are supplied they must reference the same group, else the API returns 400.
var line = new CardOrderLineModel { /* ... */ UserGroupId = 1234567890123 };
var vendor = new VendorCardOrderItemRequest { /* ... */ UserGroupId = 1234567890123 };
```

> `UserGroupId` on creation requests is honored only when the business has the cardholder-group feature enabled; otherwise the API nulls it out server-side — don't assume a supplied value is always applied.

## Tests
- Added `UserGroupSerializationTests` covering new-model (de)serialization, legacy + User Group coexistence, and PascalCase JSON casing.
- Full suite green: **60 passed, 0 failed**.

## Notes / out of scope
- The External API models `UpdateProfileRequest`, `SetCardholderGroupRequest`, `CardHolderCardResponse`, and `VirtualCardGetOrderResponse` have **no SDK counterpart** (the SDK doesn't expose those endpoints), so they were intentionally not added.
- `UserGroupBrief.GroupType` is kept as a `string` to mirror the External API wire contract (enum serialized by name) and stay forward-compatible if new group types are added.
- Package versioning is handled by CI (`VersionPrefix` placeholder), so no manual version bump is included.
- The 400-on-conflicting-`GroupId`/`UserGroupId` contract (External API `!65017`) is surfaced as-is via the existing response handling; no client-side pre-validation was added.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pexcard/pex-sdk-dotnet/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->