### PR TITLE
Add business source-attachment upload + analysis client (140671)

### DIFF
--- a/src/PexCard.Api.Client.Core/Enums/AttachmentUploadChannel.cs
+++ b/src/PexCard.Api.Client.Core/Enums/AttachmentUploadChannel.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace PexCard.Api.Client.Core.Enums
+{
+    /// <summary>
+    /// Channel a business source attachment (an emailed / SMS'd receipt or invoice) originated from.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum AttachmentUploadChannel
+    {
+        /// <summary>
+        /// The attachment was received by email; <c>Source</c> is the sender's email address.
+        /// </summary>
+        Email,
+
+        /// <summary>
+        /// The attachment was received by SMS; <c>Source</c> is the sender's phone number.
+        /// </summary>
+        Sms
+    }
+}

--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -230,6 +230,19 @@ namespace PexCard.Api.Client.Core
 
         Task<UploadBillInboxAttachmentResponseModel> UploadBillInboxAttachment(string externalToken, int billInboxId, IEnumerable<ReceiptModel> receipts, CancellationToken cancelToken = default);
 
+        /// <summary>
+        /// Uploads a business source attachment (an emailed / SMS'd receipt or invoice) for AI analysis and
+        /// auto-matching to a cardholder purchase. The <c>Source</c> must resolve to a cardholder in the
+        /// authenticated business, otherwise the API responds 403.
+        /// </summary>
+        Task<CreateBusinessAttachmentModel> UploadBusinessAttachment(string externalToken, CreateBusinessAttachmentRequestModel model, CancellationToken cancelToken = default);
+
+        /// <summary>
+        /// Gets the AI analysis for a previously uploaded business source attachment, or <see langword="null"/>
+        /// if the analysis is not available yet (the API responds 404 until it completes).
+        /// </summary>
+        Task<BusinessAttachmentAnalysisModel> GetBusinessAttachmentAnalysis(string externalToken, long metadataId, string attachmentId, CancellationToken cancelToken = default);
+
         Task<VendorListResponseModel> GetVendors(string externalToken, CancellationToken cancelToken = default);
 
         Task<VendorModel> CreateVendor(string externalToken, CreateVendorRequestModel model, CancellationToken cancelToken = default);

--- a/src/PexCard.Api.Client.Core/Models/AttachmentAnalysisDetailsModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/AttachmentAnalysisDetailsModel.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// AI analysis details for a business source attachment.
+    /// </summary>
+    public class AttachmentAnalysisDetailsModel
+    {
+        /// <summary>Analysis operation identifier.</summary>
+        public string OperationId { get; set; }
+
+        /// <summary>Analysis platform (e.g. AwsTextract, AzureDocumentAi, OpenAi, AzureOpenAi).</summary>
+        public string Platform { get; set; }
+
+        /// <summary>When the analysis record was created (UTC).</summary>
+        public DateTime CreatedDateUtc { get; set; }
+
+        /// <summary>When analysis started (UTC).</summary>
+        public DateTime? StartAnalysisDateUtc { get; set; }
+
+        /// <summary>When analysis finished (UTC).</summary>
+        public DateTime? FinishAnalysisDateUtc { get; set; }
+
+        /// <summary>Extracted/matched field criteria.</summary>
+        public AttachmentMatchCriteriaModel MatchCriteria { get; set; }
+
+        /// <summary>Model deployment used for analysis.</summary>
+        public string ModelDeployment { get; set; }
+
+        /// <summary>Intelligent (AI) match outcome.</summary>
+        public AttachmentIntelligentMatchModel IntelligentMatch { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/AttachmentIntelligentMatchModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/AttachmentIntelligentMatchModel.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Intelligent (AI) match outcome for an attachment.
+    /// </summary>
+    public class AttachmentIntelligentMatchModel
+    {
+        /// <summary>Analysis operation identifier.</summary>
+        public string OperationId { get; set; }
+
+        /// <summary>Match status (e.g. Match, NoMatch, Skip, Unknown).</summary>
+        public string Status { get; set; }
+
+        /// <summary>Reason / explanation for the match outcome.</summary>
+        public string Reason { get; set; }
+
+        /// <summary>When the match was produced (UTC).</summary>
+        public DateTime CreatedDateUtc { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/AttachmentMatchCriteriaModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/AttachmentMatchCriteriaModel.cs
@@ -1,0 +1,55 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Extracted/matched fields from attachment analysis. Each criterion is populated only when detected.
+    /// </summary>
+    public class AttachmentMatchCriteriaModel
+    {
+        public AttachmentMatchCriterionModel Merchant { get; set; }
+        public AttachmentMatchCriterionModel Total { get; set; }
+        public AttachmentMatchCriterionModel Date { get; set; }
+        public AttachmentMatchCriterionModel Time { get; set; }
+        public AttachmentMatchCriterionModel OrderDate { get; set; }
+        public AttachmentMatchCriterionModel OrderTime { get; set; }
+        public AttachmentMatchCriterionModel Last4Digits { get; set; }
+        public AttachmentMatchCriterionModel Subtotal { get; set; }
+        public AttachmentMatchCriterionModel AmountPaid { get; set; }
+        public AttachmentMatchCriterionModel Gratuity { get; set; }
+        public AttachmentMatchCriterionModel InvoiceReceiptId { get; set; }
+        public AttachmentMatchCriterionModel Pump { get; set; }
+        public AttachmentMatchCriterionModel Gallons { get; set; }
+        public AttachmentMatchCriterionModel PricePerGallon { get; set; }
+        public AttachmentMatchCriterionModel FuelProduct { get; set; }
+        public AttachmentMatchCriterionModel Currency { get; set; }
+        public AttachmentMatchCriterionModel Mcc { get; set; }
+        public AttachmentMatchCriterionModel IsFuel { get; set; }
+        public AttachmentMatchCriterionModel IsForeignCurrency { get; set; }
+        public AttachmentMatchCriterionModel IsReceipt { get; set; }
+        public AttachmentMatchCriterionModel IsInvoice { get; set; }
+        public AttachmentMatchCriterionModel IsHotel { get; set; }
+        public AttachmentMatchCriterionModel IsAirTrainTravel { get; set; }
+        public AttachmentMatchCriterionModel IsAirfare { get; set; }
+        public AttachmentMatchCriterionModel IsVehicleRental { get; set; }
+        public AttachmentMatchCriterionModel IsRideShare { get; set; }
+        public AttachmentMatchCriterionModel DueDate { get; set; }
+        public AttachmentMatchCriterionModel PaymentTerms { get; set; }
+        public AttachmentMatchCriterionModel RemitToName { get; set; }
+        public AttachmentMatchCriterionModel RemitToAddress { get; set; }
+        public AttachmentMatchCriterionModel RemitToEmail { get; set; }
+        public AttachmentMatchCriterionModel BankDetails { get; set; }
+        public AttachmentMatchCriterionModel RemitToWebsite { get; set; }
+        public AttachmentMatchCriterionModel RemitToTaxId { get; set; }
+        public AttachmentMatchCriterionModel RemitToAddress1 { get; set; }
+        public AttachmentMatchCriterionModel RemitToAddress2 { get; set; }
+        public AttachmentMatchCriterionModel RemitToCity { get; set; }
+        public AttachmentMatchCriterionModel RemitToState { get; set; }
+        public AttachmentMatchCriterionModel RemitToPostalCode { get; set; }
+        public AttachmentMatchCriterionModel RemitToContactFirstName { get; set; }
+        public AttachmentMatchCriterionModel RemitToContactLastName { get; set; }
+        public AttachmentMatchCriterionModel RemitToContactPhoneNumber { get; set; }
+        public AttachmentMatchCriterionModel RemitToContactEmail { get; set; }
+        public AttachmentMatchCriterionModel RemitToBankName { get; set; }
+        public AttachmentMatchCriterionModel RemitToBankAccountNumber { get; set; }
+        public AttachmentMatchCriterionModel RemitToBankRoutingNumber { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/AttachmentMatchCriterionModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/AttachmentMatchCriterionModel.cs
@@ -1,0 +1,20 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// A single extracted/matched field from attachment analysis.
+    /// </summary>
+    public class AttachmentMatchCriterionModel
+    {
+        /// <summary>Criterion name.</summary>
+        public string Name { get; set; }
+
+        /// <summary>Extracted value.</summary>
+        public string Value { get; set; }
+
+        /// <summary>Confidence score (0-1).</summary>
+        public float Confidence { get; set; }
+
+        /// <summary>Criterion type (e.g. MerchantName, Total, Date).</summary>
+        public string Type { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/BusinessAttachmentAnalysisModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BusinessAttachmentAnalysisModel.cs
@@ -1,0 +1,17 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// AI analysis result for a business source attachment.
+    /// </summary>
+    public class BusinessAttachmentAnalysisModel
+    {
+        /// <summary>Unique identifier of the attachment.</summary>
+        public string AttachmentId { get; set; }
+
+        /// <summary>Metadata container id the attachment belongs to.</summary>
+        public long MetadataId { get; set; }
+
+        /// <summary>Analysis details: operation, platform, timestamps, match criteria, and intelligent match.</summary>
+        public AttachmentAnalysisDetailsModel Analysis { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentModel.cs
@@ -1,0 +1,18 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Result of uploading a business source attachment.
+    /// </summary>
+    public class CreateBusinessAttachmentModel : AttachmentBaseModel
+    {
+        /// <summary>
+        /// Metadata container id assigned to the uploaded attachment; used to fetch its analysis.
+        /// </summary>
+        public long MetadataId { get; set; }
+
+        /// <summary>
+        /// Link to the analysis resource for this attachment.
+        /// </summary>
+        public LinkSelfModel Link { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using PexCard.Api.Client.Core.Enums;
+
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Request to upload a business source attachment (an emailed / SMS'd receipt or invoice) for AI analysis
+    /// and auto-matching to a cardholder purchase. The <see cref="Source"/> must resolve to a cardholder in the
+    /// authenticated business.
+    /// </summary>
+    public class CreateBusinessAttachmentRequestModel
+    {
+        /// <summary>
+        /// Base64-encoded file contents (raw base64, not a data URI). Required.
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Attachment type (Image or Pdf). Required.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public AttachmentType Type { get; set; }
+
+        /// <summary>
+        /// Channel the attachment originated from (Email or Sms). Required.
+        /// </summary>
+        public AttachmentUploadChannel UploadChannel { get; set; }
+
+        /// <summary>
+        /// Sender identifier used to resolve the cardholder: email address (Email) or phone number (Sms). Required.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Optional original file name.
+        /// </summary>
+        public string FileName { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/LinkSelfModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/LinkSelfModel.cs
@@ -1,0 +1,13 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// A self link to a resource.
+    /// </summary>
+    public class LinkSelfModel
+    {
+        /// <summary>
+        /// URL of the resource.
+        /// </summary>
+        public string Self { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -1721,6 +1721,35 @@ namespace PexCard.Api.Client
             }
         }
 
+        public async Task<CreateBusinessAttachmentModel> UploadBusinessAttachment(string externalToken, CreateBusinessAttachmentRequestModel model, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Business/Attachments"));
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+            request.SetPexJsonContent(model);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<CreateBusinessAttachmentModel>(response);
+        }
+
+        public async Task<BusinessAttachmentAnalysisModel> GetBusinessAttachmentAnalysis(string externalToken, long metadataId, string attachmentId, CancellationToken cancelToken = default)
+        {
+            var requestUriBuilder = new UriBuilder(new Uri(BaseUri, $"V4/Business/Attachments/{metadataId}/{attachmentId}/Analysis"));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUriBuilder.Uri);
+            request.SetPexCorrelationIdHeader(_correlationIdResolver.GetValue());
+            request.SetPexAcceptJsonHeader();
+            request.SetPexAuthorizationTokenHeader(externalToken);
+
+            var response = await _httpClient.SendAsync(request, cancelToken);
+
+            return await HandleHttpResponseMessage<BusinessAttachmentAnalysisModel>(response, returnValueForNotFound: true);
+        }
+
         public async Task<VendorListResponseModel> GetVendors(string externalToken, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Vendor"));

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
@@ -1,0 +1,86 @@
+using Newtonsoft.Json;
+using PexCard.Api.Client.Core.Enums;
+using PexCard.Api.Client.Core.Models;
+using Xunit;
+
+namespace PexCard.Api.Client.Core.Tests.Serialization
+{
+    public class BusinessAttachmentSerializationTests
+    {
+        [Fact]
+        public void CreateBusinessAttachmentRequest_SerializesEnumsAsStringNames()
+        {
+            var request = new CreateBusinessAttachmentRequestModel
+            {
+                Content = "SGVsbG8=",
+                Type = AttachmentType.Pdf,
+                UploadChannel = AttachmentUploadChannel.Email,
+                Source = "sender@pexcard.com",
+                FileName = "receipt.pdf"
+            };
+
+            var json = JsonConvert.SerializeObject(request);
+
+            // Must serialize by NAME — the SDK AttachmentType (Image=0,Pdf=1) differs from the API's
+            // underlying values, so an integer would map to the wrong type on the wire.
+            Assert.Contains("\"Type\":\"Pdf\"", json);
+            Assert.Contains("\"UploadChannel\":\"Email\"", json);
+            Assert.DoesNotContain("\"Type\":1", json);
+            Assert.DoesNotContain("\"UploadChannel\":0", json);
+        }
+
+        [Fact]
+        public void CreateBusinessAttachmentRequest_OmitsUnsetOptionalFields()
+        {
+            var request = new CreateBusinessAttachmentRequestModel
+            {
+                Content = "SGVsbG8=",
+                Type = AttachmentType.Image,
+                UploadChannel = AttachmentUploadChannel.Sms,
+                Source = "+15555550100"
+            };
+
+            var json = JsonConvert.SerializeObject(
+                request,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+            Assert.DoesNotContain("FileName", json);
+        }
+
+        [Fact]
+        public void CreateBusinessAttachment_DeserializesMetadataIdAndSelfLink()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555,\"Link\":{\"self\":\"https://api.pexcard.com/Business/Attachments/555/att-1/Analysis\"}}";
+
+            var model = JsonConvert.DeserializeObject<CreateBusinessAttachmentModel>(json);
+
+            Assert.Equal("att-1", model.AttachmentId);
+            Assert.Equal(AttachmentType.Pdf, model.Type);
+            Assert.Equal(555, model.MetadataId);
+            Assert.NotNull(model.Link);
+            Assert.Equal("https://api.pexcard.com/Business/Attachments/555/att-1/Analysis", model.Link.Self);
+        }
+
+        [Fact]
+        public void BusinessAttachmentAnalysis_DeserializesNestedGraph()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"MetadataId\":555,\"Analysis\":{" +
+                "\"OperationId\":\"op-9\",\"Platform\":\"OpenAi\",\"ModelDeployment\":\"gpt-x\"," +
+                "\"MatchCriteria\":{\"Merchant\":{\"Name\":\"Merchant\",\"Value\":\"Acme\",\"Confidence\":0.95,\"Type\":\"MerchantName\"}}," +
+                "\"IntelligentMatch\":{\"OperationId\":\"op-9\",\"Status\":\"Match\",\"Reason\":\"matched on total+date\"}}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentAnalysisModel>(json);
+
+            Assert.Equal("att-1", model.AttachmentId);
+            Assert.Equal(555, model.MetadataId);
+            Assert.NotNull(model.Analysis);
+            Assert.Equal("op-9", model.Analysis.OperationId);
+            Assert.Equal("OpenAi", model.Analysis.Platform);
+            Assert.NotNull(model.Analysis.MatchCriteria?.Merchant);
+            Assert.Equal("Acme", model.Analysis.MatchCriteria.Merchant.Value);
+            Assert.Equal(0.95f, model.Analysis.MatchCriteria.Merchant.Confidence);
+            Assert.Equal("MerchantName", model.Analysis.MatchCriteria.Merchant.Type);
+            Assert.Equal("Match", model.Analysis.IntelligentMatch?.Status);
+        }
+    }
+}


### PR DESCRIPTION
[AB#140671](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140671)

## Summary

- Adds the PEX API client methods for the new External API business source-attachment endpoints (successor to the External API story [AB#140670](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140670)):
  - `UploadBusinessAttachment` → `POST V4/Business/Attachments`
  - `GetBusinessAttachmentAnalysis` → `GET V4/Business/Attachments/{metadataId}/{attachmentId}/Analysis` (returns `null` on 404 until analysis completes)
- Mirrors the API's own-DTO contract: `CreateBusinessAttachmentRequestModel`, `CreateBusinessAttachmentModel` (+ `MetadataId`, `LinkSelfModel`), and the analysis graph (`BusinessAttachmentAnalysisModel` → `AttachmentAnalysisDetailsModel` → `AttachmentMatchCriteriaModel` + `AttachmentMatchCriterionModel` + `AttachmentIntelligentMatchModel`). Analysis enum fields (`Platform`, `Status`, criterion `Type`) are exposed as strings.
- New `AttachmentUploadChannel { Email, Sms }` enum.

## Enum-on-the-wire note

Request enums serialize by **name**, not integer: the SDK's `AttachmentType` (`Image=0,Pdf=1`) differs from the API's underlying values (`Image=1,Pdf=2`), so an integer would map to the wrong type. The External API's `StrictEnumConverter`/`NullableEnumConverter` parse names on input, and the non-nullable response `Type` is emitted as a name, so both directions are correct.

## Tests

- 4 serialization tests (enum-by-name, self-link, nested analysis graph). Full suite green (64 tests).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pexcard/pex-sdk-dotnet/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->