### PR TITLE
AB#140671 PEX SDK: optional note + richer response on business attachment upload

### DIFF
--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentModel.cs
@@ -1,3 +1,5 @@
+using PexCard.Api.Client.Core.Enums;
+
 namespace PexCard.Api.Client.Core.Models
 {
     /// <summary>
@@ -9,6 +11,31 @@ namespace PexCard.Api.Client.Core.Models
         /// Metadata container id assigned to the uploaded attachment; used to fetch its analysis.
         /// </summary>
         public long MetadataId { get; set; }
+
+        /// <summary>
+        /// Stored file name of the attachment.
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Number of pages (for multi-page documents such as PDFs).
+        /// </summary>
+        public int Pages { get; set; }
+
+        /// <summary>
+        /// When the upload was detected as a duplicate, the id of the existing attachment it duplicates; otherwise null.
+        /// </summary>
+        public string DuplicateOfId { get; set; }
+
+        /// <summary>
+        /// Channel the attachment originated from (Email or Sms).
+        /// </summary>
+        public AttachmentUploadChannel UploadChannel { get; set; }
+
+        /// <summary>
+        /// Sender identifier the attachment was uploaded for (email address or phone number).
+        /// </summary>
+        public string Source { get; set; }
 
         /// <summary>
         /// Link to the analysis resource for this attachment.

--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentNoteModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentNoteModel.cs
@@ -1,0 +1,26 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Optional note to apply to the transaction a business source attachment is matched to.
+    /// All fields are optional; when omitted the service defaults visibility to the cardholder
+    /// (<see cref="VisibleToCardholder"/> = true) and treats the note as not system-generated
+    /// (<see cref="IsSystemGenerated"/> = false).
+    /// </summary>
+    public class CreateBusinessAttachmentNoteModel
+    {
+        /// <summary>
+        /// Note text. Max 255 characters. No note is created when null/empty.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Whether the note is visible to the cardholder. Defaults to true when omitted.
+        /// </summary>
+        public bool? VisibleToCardholder { get; set; }
+
+        /// <summary>
+        /// Whether the note is system-generated (vs. authored by a person). Defaults to false when omitted.
+        /// </summary>
+        public bool? IsSystemGenerated { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
@@ -36,5 +36,10 @@ namespace PexCard.Api.Client.Core.Models
         /// Optional original file name.
         /// </summary>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// Optional note applied to the transaction the attachment is matched to. Omit to add no note.
+        /// </summary>
+        public CreateBusinessAttachmentNoteModel Note { get; set; }
     }
 }

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
@@ -45,6 +45,48 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
                 new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
             Assert.DoesNotContain("FileName", json);
+            Assert.DoesNotContain("Note", json);
+        }
+
+        [Fact]
+        public void CreateBusinessAttachmentRequest_SerializesNestedNote()
+        {
+            var request = new CreateBusinessAttachmentRequestModel
+            {
+                Content = "SGVsbG8=",
+                Type = AttachmentType.Image,
+                UploadChannel = AttachmentUploadChannel.Email,
+                Source = "sender@pexcard.com",
+                Note = new CreateBusinessAttachmentNoteModel
+                {
+                    Text = "Client lunch - please reimburse",
+                    VisibleToCardholder = true,
+                    IsSystemGenerated = false
+                }
+            };
+
+            var json = JsonConvert.SerializeObject(request);
+
+            Assert.Contains("\"Note\":{", json);
+            Assert.Contains("\"Text\":\"Client lunch - please reimburse\"", json);
+            Assert.Contains("\"VisibleToCardholder\":true", json);
+            Assert.Contains("\"IsSystemGenerated\":false", json);
+        }
+
+        [Fact]
+        public void CreateBusinessAttachment_DeserializesNewResponseFields()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Image\",\"Size\":84213,\"MetadataId\":555," +
+                "\"FileName\":\"Email-jane@company.com.jpg\",\"Pages\":1,\"DuplicateOfId\":null," +
+                "\"UploadChannel\":\"Email\",\"Source\":\"jane@company.com\"}";
+
+            var model = JsonConvert.DeserializeObject<CreateBusinessAttachmentModel>(json);
+
+            Assert.Equal("Email-jane@company.com.jpg", model.FileName);
+            Assert.Equal(1, model.Pages);
+            Assert.Null(model.DuplicateOfId);
+            Assert.Equal(AttachmentUploadChannel.Email, model.UploadChannel);
+            Assert.Equal("jane@company.com", model.Source);
         }
 
         [Fact]


### PR DESCRIPTION
Linked work item: [AB#140671](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140671)

## Summary
Mirrors the External API change ([AB#141034](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141034)) in the .NET SDK so consumers can attach an optional note when uploading a business source attachment, and get richer details back.

## Changes
- `CreateBusinessAttachmentRequestModel` gains an optional nested **`Note`** object — `CreateBusinessAttachmentNoteModel` { `Text` (≤255, optional), `VisibleToCardholder` (optional), `IsSystemGenerated` (optional) }. Omit `Note` for no note; the service defaults visibility to the cardholder (true) and system-generated to false.
- `CreateBusinessAttachmentModel` (response) gains **`FileName`**, **`Pages`**, **`DuplicateOfId`**, **`UploadChannel`**, **`Source`**.
- Serialization tests added; full Core test suite passes (66).

## Notes
Additive + optional — no breaking change for existing SDK consumers. Backed by External API [AB#141034](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141034) (merged + published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)