### PR TITLE
AB#141575 AB#140671 Add UserName/FirstName/LastName to MetadataUserModel

### DIFF
--- a/src/PexCard.Api.Client.Core/Models/MetadataUserModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/MetadataUserModel.cs
@@ -1,18 +1,23 @@
-﻿namespace PexCard.Api.Client.Core.Models
+namespace PexCard.Api.Client.Core.Models
 {
     public class MetadataUserModel
     {
+        /// <summary>Admin id, when the actor is an admin.</summary>
         public int? AdminId { get; set; }
+
+        /// <summary>Cardholder/user account id, when the actor is a cardholder.</summary>
         public int? UserId { get; set; }
+
+        /// <summary>Platform (security) user id.</summary>
         public long? PexUserId { get; set; }
 
-        /// <summary>Login / username of the user, resolved by the External API from the admin/cardholder id; null when not resolvable.</summary>
+        /// <summary>Login / username; null when the identity cannot be resolved.</summary>
         public string UserName { get; set; }
 
-        /// <summary>First name of the user, resolved by the External API; null when not resolvable.</summary>
+        /// <summary>First name; null when the identity cannot be resolved.</summary>
         public string FirstName { get; set; }
 
-        /// <summary>Last name of the user, resolved by the External API; null when not resolvable.</summary>
+        /// <summary>Last name; null when the identity cannot be resolved.</summary>
         public string LastName { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/MetadataUserModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/MetadataUserModel.cs
@@ -5,5 +5,14 @@
         public int? AdminId { get; set; }
         public int? UserId { get; set; }
         public long? PexUserId { get; set; }
+
+        /// <summary>Login / username of the user, resolved by the External API from the admin/cardholder id; null when not resolvable.</summary>
+        public string UserName { get; set; }
+
+        /// <summary>First name of the user, resolved by the External API; null when not resolvable.</summary>
+        public string FirstName { get; set; }
+
+        /// <summary>Last name of the user, resolved by the External API; null when not resolvable.</summary>
+        public string LastName { get; set; }
     }
 }

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
@@ -133,7 +133,8 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
                 "\"FileName\":\"receipt.png\",\"UploadChannel\":\"Email\",\"Match\":{" +
                 "\"Status\":\"AutoMatch\",\"SuggestedMatchId\":\"sm-9\",\"NoMatchDateUtc\":null," +
                 "\"CommitDateUtc\":\"2026-06-26T14:09:30Z\",\"MatchRetryCount\":0,\"Matched\":{" +
-                "\"DateUtc\":\"2026-06-26T14:09:30Z\",\"By\":{\"AdminId\":null,\"UserId\":552201,\"PexUserId\":99812}}}}";
+                "\"DateUtc\":\"2026-06-26T14:09:30Z\",\"By\":{\"AdminId\":null,\"UserId\":552201,\"PexUserId\":99812," +
+                "\"UserName\":\"jdoe\",\"FirstName\":\"Jane\",\"LastName\":\"Doe\"}}}}";
 
             var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
 
@@ -155,6 +156,9 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
             Assert.NotNull(model.Match.Matched.By);
             Assert.Equal(552201, model.Match.Matched.By.UserId);
             Assert.Equal(99812, model.Match.Matched.By.PexUserId);
+            Assert.Equal("jdoe", model.Match.Matched.By.UserName);
+            Assert.Equal("Jane", model.Match.Matched.By.FirstName);
+            Assert.Equal("Doe", model.Match.Matched.By.LastName);
         }
 
         [Fact]

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
@@ -162,6 +162,23 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
         }
 
         [Fact]
+        public void BusinessAttachment_MetadataUserNames_NullWhenAbsent()
+        {
+            // Old API format (or unresolved identity): the By object omits the name fields entirely.
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Match\":{\"Status\":\"AutoMatch\",\"Matched\":{" +
+                "\"DateUtc\":\"2026-06-26T14:09:30Z\",\"By\":{\"AdminId\":null,\"UserId\":552201,\"PexUserId\":99812}}}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.NotNull(model.Match.Matched.By);
+            Assert.Equal(552201, model.Match.Matched.By.UserId);
+            Assert.Null(model.Match.Matched.By.UserName);
+            Assert.Null(model.Match.Matched.By.FirstName);
+            Assert.Null(model.Match.Matched.By.LastName);
+        }
+
+        [Fact]
         public void BusinessAttachment_DeserializesNullMatch()
         {
             const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555," +


### PR DESCRIPTION
[AB#141575](https://pexcard.visualstudio.com/PEX%20Processing%20Solution/_workitems/edit/141575) · [AB#140671](https://pexcard.visualstudio.com/PEX%20Processing%20Solution/_workitems/edit/140671)

Adds `UserName`, `FirstName`, `LastName` to `MetadataUserModel`, the SDK counterpart to the External API change that resolves the admin/cardholder id to a username + name (External API [AB#140670](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/140670) / [AB#141434](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141434)).

## Changes
- `PexCard.Api.Client.Core/Models/MetadataUserModel.cs`: added `UserName`, `FirstName`, `LastName` (alongside `AdminId`/`UserId`/`PexUserId`).
- These populate `createdBy` / `updatedBy` (upload response) and `match.matched.by` (GET committed match). Additive — names are null when the External API can't resolve them; existing consumers are unaffected.
- Extended the `BusinessAttachmentModel` committed-match deserialization test to assert the new name fields on `Matched.By`.

Build + tests pass (Core solution builds clean; serialization tests 10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)