### PR TITLE
142425 PexSdkDotNet: Bill Date filter on Bills client + IncludeVendorBillPay on cardholder transactions

### DIFF
--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -51,7 +51,7 @@ namespace PexCard.Api.Client.Core
 
         Task<int> GetAllCardholderTransactionsCount(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 
-        Task<CardholderTransactions> GetAllCardholderTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default);
+        Task<CardholderTransactions> GetAllCardholderTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, bool includeVendorBillPay = true, CancellationToken cancelToken = default);
 
         Task<CardholderTransactions> GetCardholderTransactions(string externalToken, int cardholderAccountId, DateTime startDate, DateTime endDate, bool includePending = false, bool includeDeclines = false, CancellationToken cancelToken = default);
 

--- a/src/PexCard.Api.Client.Core/Models/BillPaymentListRequestModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BillPaymentListRequestModel.cs
@@ -14,6 +14,10 @@ namespace PexCard.Api.Client.Core.Models
 
         public DateTime? DueDateTo { get; set; }
 
+        public DateTime? BillDateFrom { get; set; }
+
+        public DateTime? BillDateTo { get; set; }
+
         public long? CreatedByUserId { get; set; }
 
         public int? VendorId { get; set; }

--- a/src/PexCard.Api.Client.Core/Models/BillPaymentModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BillPaymentModel.cs
@@ -25,6 +25,8 @@ namespace PexCard.Api.Client.Core.Models
 
         public DateTimeOffset? DueDate { get; set; }
 
+        public DateTimeOffset? BillDate { get; set; }
+
         public PaymentRequestStatus PaymentRequestStatus { get; set; }
 
         public PaymentRequestStatusTrigger PaymentRequestStatusTrigger { get; set; }

--- a/src/PexCard.Api.Client/PexApiClient.cs
+++ b/src/PexCard.Api.Client/PexApiClient.cs
@@ -180,13 +180,14 @@ namespace PexCard.Api.Client
             return await HandleHttpResponseMessage<int>(response);
         }
 
-        public async Task<CardholderTransactions> GetAllCardholderTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, CancellationToken cancelToken = default)
+        public async Task<CardholderTransactions> GetAllCardholderTransactions(string externalToken, DateTime startDate, DateTime endDate, bool includePendings = false, bool includeDeclines = false, bool includeVendorBillPay = true, CancellationToken cancelToken = default)
         {
             var requestUriBuilder = new UriBuilder(new Uri(BaseUri, "V4/Details/AllCardholderTransactions"));
 
             var requestUriQueryParams = HttpUtility.ParseQueryString(requestUriBuilder.Query);
             requestUriQueryParams.Add("IncludePendings", includePendings.ToString());
             requestUriQueryParams.Add("IncludeDeclines", includeDeclines.ToString());
+            requestUriQueryParams.Add("IncludeVendorBillPay", includeVendorBillPay.ToString());
             requestUriQueryParams.Add("StartDate", startDate.ToEst().ToDateTimeString());
             requestUriQueryParams.Add("EndDate", endDate.ToEst().ToDateTimeString());
             requestUriBuilder.Query = requestUriQueryParams.ToString();
@@ -1504,6 +1505,14 @@ namespace PexCard.Api.Client
                 if (model.DueDateTo.HasValue)
                 {
                     requestUriQueryParams.Add("DueDateTo", model.DueDateTo.Value.ToEst().ToDateTimeString());
+                }
+                if (model.BillDateFrom.HasValue)
+                {
+                    requestUriQueryParams.Add("BillDateFrom", model.BillDateFrom.Value.ToEst().ToDateTimeString());
+                }
+                if (model.BillDateTo.HasValue)
+                {
+                    requestUriQueryParams.Add("BillDateTo", model.BillDateTo.Value.ToEst().ToDateTimeString());
                 }
                 if (model.CreatedByUserId.HasValue)
                 {

--- a/tests/PexCard.Api.Client.Core.Tests/PexApiClientBillPaymentTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/PexApiClientBillPaymentTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using PexCard.Api.Client.Core.Models;
+using Xunit;
+
+namespace PexCard.Api.Client.Core.Tests
+{
+    public class PexApiClientBillPaymentTests
+    {
+        private const string Token = "ext-token";
+
+        [Fact]
+        public async Task GetBillPayments_IncludesBillDateFilters_InQuery()
+        {
+            string capturedQuery = null;
+            var handler = new StubHandler(req =>
+            {
+                capturedQuery = req.RequestUri?.Query;
+                return Ok();
+            });
+            var client = CreateClient(handler);
+
+            var model = new BillPaymentListRequestModel
+            {
+                BillDateFrom = new DateTime(2026, 1, 1),
+                BillDateTo = new DateTime(2026, 1, 31),
+            };
+
+            await client.GetBillPayments(Token, model);
+
+            Assert.NotNull(capturedQuery);
+            Assert.Contains("BillDateFrom=", capturedQuery);
+            Assert.Contains("BillDateTo=", capturedQuery);
+        }
+
+        [Fact]
+        public async Task GetBillPayments_OmitsBillDateFilters_WhenNotSet()
+        {
+            string capturedQuery = null;
+            var handler = new StubHandler(req =>
+            {
+                capturedQuery = req.RequestUri?.Query;
+                return Ok();
+            });
+            var client = CreateClient(handler);
+
+            await client.GetBillPayments(Token, new BillPaymentListRequestModel());
+
+            Assert.NotNull(capturedQuery);
+            Assert.DoesNotContain("BillDate", capturedQuery);
+        }
+
+        private static PexApiClient CreateClient(HttpMessageHandler handler)
+        {
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://coreapi.example/") };
+            return new PexApiClient(httpClient);
+        }
+
+        private static HttpResponseMessage Ok()
+        {
+            var body = JsonConvert.SerializeObject(new BillPaymentListResponseModel
+            {
+                Items = new List<BillPaymentModel>(),
+                PageInfo = new PageInfoModel { Page = 1, PageSize = 15, TotalItems = 0 },
+            });
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) };
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+            public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/PexCard.Api.Client.Core.Tests/PexApiClientTransactionsTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/PexApiClientTransactionsTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PexCard.Api.Client.Core.Tests
+{
+    public class PexApiClientTransactionsTests
+    {
+        private const string Token = "ext-token";
+
+        [Fact]
+        public async Task GetAllCardholderTransactions_DefaultsIncludeVendorBillPayTrue_InQuery()
+        {
+            string capturedQuery = null;
+            var handler = new StubHandler(req =>
+            {
+                capturedQuery = req.RequestUri?.Query;
+                return Ok();
+            });
+            var client = CreateClient(handler);
+
+            await client.GetAllCardholderTransactions(Token, new DateTime(2026, 1, 1), new DateTime(2026, 1, 31));
+
+            Assert.NotNull(capturedQuery);
+            Assert.Contains("IncludeVendorBillPay=True", capturedQuery);
+        }
+
+        [Fact]
+        public async Task GetAllCardholderTransactions_HonorsIncludeVendorBillPayFalse_InQuery()
+        {
+            string capturedQuery = null;
+            var handler = new StubHandler(req =>
+            {
+                capturedQuery = req.RequestUri?.Query;
+                return Ok();
+            });
+            var client = CreateClient(handler);
+
+            await client.GetAllCardholderTransactions(Token, new DateTime(2026, 1, 1), new DateTime(2026, 1, 31), includeVendorBillPay: false);
+
+            Assert.NotNull(capturedQuery);
+            Assert.Contains("IncludeVendorBillPay=False", capturedQuery);
+        }
+
+        private static PexApiClient CreateClient(HttpMessageHandler handler)
+        {
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://coreapi.example/") };
+            return new PexApiClient(httpClient);
+        }
+
+        private static HttpResponseMessage Ok()
+            => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"TransactionList\":[]}") };
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+            public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BillPaymentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BillPaymentSerializationTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using PexCard.Api.Client.Core.Models;
+using Xunit;
+
+namespace PexCard.Api.Client.Core.Tests.Serialization
+{
+    public class BillPaymentSerializationTests
+    {
+        [Fact]
+        public void BillPaymentModel_DeserializesBillDateFromServer()
+        {
+            const string json = @"{
+                ""BillId"": 501,
+                ""BillRefNo"": ""INV-501"",
+                ""Amount"": 250.00,
+                ""Created"": ""2026-01-20T00:00:00+00:00"",
+                ""DueDate"": ""2026-02-01T00:00:00+00:00"",
+                ""BillDate"": ""2026-01-15T00:00:00+00:00""
+            }";
+
+            var model = JsonConvert.DeserializeObject<BillPaymentModel>(json);
+
+            Assert.Equal(501, model.BillId);
+            Assert.Equal(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero), model.BillDate);
+            Assert.Equal(new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero), model.DueDate);
+        }
+
+        [Fact]
+        public void BillPaymentModel_OmitsBillDate_WhenNull()
+        {
+            var model = new BillPaymentModel { BillId = 1 };
+
+            var json = JsonConvert.SerializeObject(
+                model,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+            Assert.DoesNotContain("BillDate", json);
+        }
+
+        [Fact]
+        public void BillPaymentListResponse_RoundTripsBillDate()
+        {
+            var original = new BillPaymentListResponseModel
+            {
+                Items = new List<BillPaymentModel>
+                {
+                    new BillPaymentModel
+                    {
+                        BillId = 7,
+                        BillDate = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero),
+                        DueDate = new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero),
+                    }
+                },
+                PageInfo = new PageInfoModel { Page = 1, PageSize = 15, TotalItems = 1 }
+            };
+
+            var json = JsonConvert.SerializeObject(original);
+            var roundTripped = JsonConvert.DeserializeObject<BillPaymentListResponseModel>(json);
+
+            Assert.Single(roundTripped.Items);
+            Assert.Equal(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero), roundTripped.Items[0].BillDate);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Two SDK additions under the QBO Bill Date initiative ([AB#141655](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141655)), aligning `PexCard.Api.Client` with recent External API changes:

### 1. Bill Date filter on the Bills client ([AB#142420](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/142420))
Matches External API `GET /V4/Bill` ([AB#141659](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141659)), which proxies to the Invoicing bill payment search ([AB#141657](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/141657)).
- `BillPaymentListRequestModel`: new optional `BillDateFrom` / `BillDateTo` (`DateTime?`).
- `PexApiClient.GetBillPayments`: serialize `BillDateFrom` / `BillDateTo` into the `V4/Bill` query string, using the same EST formatting as `CreatedDate` / `DueDate`.
- `BillPaymentModel`: new `BillDate` (`DateTimeOffset?`) returned per bill.

### 2. IncludeVendorBillPay on cardholder transactions
Matches External API PR 67661 (commit d21f50be), which added `@IncludeVendorBillPay` to `AllCardholderTransactionsForBusiness`.
- `IPexApiClient` / `PexApiClient.GetAllCardholderTransactions`: new `includeVendorBillPay` parameter (default `true`) sent as the `IncludeVendorBillPay` query parameter on `V4/Details/AllCardholderTransactions`.

## Backward compatibility
All new inputs are optional; defaults preserve existing behavior (Bill Date filters omitted; `IncludeVendorBillPay=true`).

## Test plan
- `BillPaymentSerializationTests`: `BillPaymentModel` (de)serializes `BillDate`, omits when null, round-trips in `BillPaymentListResponseModel`.
- `PexApiClientBillPaymentTests`: `GetBillPayments` includes/omits `BillDateFrom`/`BillDateTo` in the query.
- `PexApiClientTransactionsTests`: `GetAllCardholderTransactions` sends `IncludeVendorBillPay` (default `True`; honors `false`).
- Test project builds (net8.0); the 7 new tests pass locally.

[AB#142420](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/142420)
