### PR TITLE
AB#144795: Carry a dependency source on the tag-option dependency models

### DIFF
--- a/src/PexCard.Api.Client.Core/Models/CreateTagOptionsDependencyModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateTagOptionsDependencyModel.cs
@@ -7,5 +7,11 @@ namespace PexCard.Api.Client.Core.Models
         public string DependsOnTagId { get; set; }
         public List<CreateTagOptionsDependencyRuleModel> Rules { get; set; }
         public TagOptionsDependencyDefaultModel Default { get; set; }
+
+        /// <summary>
+        /// What is creating the dependency. Optional — leave it null and the dependency is
+        /// attributed to the user whose token the request runs under.
+        /// </summary>
+        public TagDependencySourceModel Source { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/TagDependencySourceModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/TagDependencySourceModel.cs
@@ -1,0 +1,18 @@
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Identifies what is creating or updating a tag dependency, as opposed to
+    /// <see cref="TagDependencyAuditModel"/> which identifies who.
+    /// Set this so the dependency is attributed to your integration rather than to the user
+    /// whose token the request runs under.
+    /// </summary>
+    public class TagDependencySourceModel
+    {
+        /// <summary>
+        /// The name of the integration making the change.
+        /// PEX recognises a fixed set of names; an unrecognised one is recorded as unknown rather
+        /// than rejected, so a typo fails silently.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/UpdateTagOptionsDependencyModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/UpdateTagOptionsDependencyModel.cs
@@ -7,5 +7,11 @@ namespace PexCard.Api.Client.Core.Models
         public string DependsOnTagId { get; set; }
         public List<UpdateTagOptionsDependencyRuleModel> Rules { get; set; }
         public TagOptionsDependencyDefaultModel Default { get; set; }
+
+        /// <summary>
+        /// What is updating the dependency. Optional — leave it null and the update is attributed
+        /// to the user whose token the request runs under.
+        /// </summary>
+        public TagDependencySourceModel Source { get; set; }
     }
 }


### PR DESCRIPTION
Lets a connector say what it is when it creates or updates a tag dependency, so the dependency is attributed to the integration rather than to the admin whose token the sync runs under. 

[AB#144795](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/144795)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pexcard/pex-sdk-dotnet/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->