### PR TITLE
AB#145692: Mirror Business Attachments API changes in the SDK models

### DIFF
--- a/src/PexCard.Api.Client.Core/IPexApiClient.cs
+++ b/src/PexCard.Api.Client.Core/IPexApiClient.cs
@@ -233,7 +233,8 @@ namespace PexCard.Api.Client.Core
         /// <summary>
         /// Uploads a business source attachment (an emailed / SMS'd receipt or invoice) for AI analysis and
         /// auto-matching to a cardholder purchase. The <c>Source</c> must resolve to a cardholder in the
-        /// authenticated business, otherwise the API responds 403.
+        /// authenticated business, otherwise the API responds 403 — unless <c>EnforceCardholderEmail</c> is
+        /// false, in which case the attachment is stored against the business, unattributed.
         /// </summary>
         Task<CreateBusinessAttachmentModel> UploadBusinessAttachment(string externalToken, CreateBusinessAttachmentRequestModel model, CancellationToken cancelToken = default);
 
@@ -246,7 +247,8 @@ namespace PexCard.Api.Client.Core
         /// <summary>
         /// Gets a previously uploaded business source attachment, including its committed match state, or
         /// <see langword="null"/> if it does not exist (the API responds 404). Unlike the analysis, this
-        /// reflects the committed match (what the Dashboard shows) regardless of AI analysis.
+        /// reflects the committed match (what the Dashboard shows) regardless of AI analysis. The returned
+        /// <c>Links</c> are short-lived — call this again when they are needed instead of storing them.
         /// </summary>
         Task<BusinessAttachmentModel> GetBusinessAttachment(string externalToken, long metadataId, string attachmentId, CancellationToken cancelToken = default);
 

--- a/src/PexCard.Api.Client.Core/Models/BusinessAttachmentLinksModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BusinessAttachmentLinksModel.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace PexCard.Api.Client.Core.Models
+{
+    /// <summary>
+    /// Presigned links to a business source attachment's file content. Short-lived: re-fetch the attachment
+    /// when the links are needed rather than storing them, since they stop working at <see cref="Expiration"/>.
+    /// </summary>
+    public class BusinessAttachmentLinksModel
+    {
+        /// <summary>Link to the full-size file.</summary>
+        public string Full { get; set; }
+
+        /// <summary>Link to the thumbnail rendition, when one is available.</summary>
+        public string Thumbnail { get; set; }
+
+        /// <summary>UTC instant at which the links stop working.</summary>
+        public DateTime Expiration { get; set; }
+    }
+}

--- a/src/PexCard.Api.Client.Core/Models/BusinessAttachmentMatchModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BusinessAttachmentMatchModel.cs
@@ -24,5 +24,14 @@ namespace PexCard.Api.Client.Core.Models
 
         /// <summary>Who/when finalized the match; null until matched.</summary>
         public BusinessAttachmentMatchedByModel Matched { get; set; }
+
+        /// <summary>Auth transaction id of the matched transaction; null when unmatched.</summary>
+        public long? AuthTranId { get; set; }
+
+        /// <summary>Network transaction id of the matched transaction; null when unmatched.</summary>
+        public long? NetworkTranId { get; set; }
+
+        /// <summary>Settled transaction id (the same id /Details uses); null while the transaction is pending (auth-only), set once settled.</summary>
+        public long? TransactionId { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/BusinessAttachmentModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/BusinessAttachmentModel.cs
@@ -16,7 +16,13 @@ namespace PexCard.Api.Client.Core.Models
         /// <summary>Channel the attachment originated from (Email or Sms).</summary>
         public AttachmentUploadChannel UploadChannel { get; set; }
 
+        /// <summary>Sender the attachment arrived from: email address (Email) or phone number (Sms).</summary>
+        public string Source { get; set; }
+
         /// <summary>Committed match state; null when no match activity has occurred yet.</summary>
         public BusinessAttachmentMatchModel Match { get; set; }
+
+        /// <summary>Presigned links to the file content; null when none are available.</summary>
+        public BusinessAttachmentLinksModel Links { get; set; }
     }
 }

--- a/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
+++ b/src/PexCard.Api.Client.Core/Models/CreateBusinessAttachmentRequestModel.cs
@@ -7,7 +7,7 @@ namespace PexCard.Api.Client.Core.Models
     /// <summary>
     /// Request to upload a business source attachment (an emailed / SMS'd receipt or invoice) for AI analysis
     /// and auto-matching to a cardholder purchase. The <see cref="Source"/> must resolve to a cardholder in the
-    /// authenticated business.
+    /// authenticated business unless <see cref="EnforceCardholderEmail"/> is false.
     /// </summary>
     public class CreateBusinessAttachmentRequestModel
     {
@@ -28,7 +28,7 @@ namespace PexCard.Api.Client.Core.Models
         public AttachmentUploadChannel UploadChannel { get; set; }
 
         /// <summary>
-        /// Sender identifier used to resolve the cardholder: email address (Email) or phone number (Sms). Required.
+        /// Sender identifier: email address (Email) or phone number (Sms). Required.
         /// </summary>
         public string Source { get; set; }
 
@@ -36,6 +36,12 @@ namespace PexCard.Api.Client.Core.Models
         /// Optional original file name.
         /// </summary>
         public string FileName { get; set; }
+
+        /// <summary>
+        /// Whether <see cref="Source"/> must resolve to a cardholder in the business. Defaults to true.
+        /// When false the attachment is stored against the business, unattributed.
+        /// </summary>
+        public bool EnforceCardholderEmail { get; set; } = true;
 
         /// <summary>
         /// Optional note applied to the transaction the attachment is matched to. Omit to add no note.

--- a/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
+++ b/tests/PexCard.Api.Client.Core.Tests/Serialization/BusinessAttachmentSerializationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 using PexCard.Api.Client.Core.Enums;
 using PexCard.Api.Client.Core.Models;
@@ -46,6 +47,40 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
 
             Assert.DoesNotContain("FileName", json);
             Assert.DoesNotContain("Note", json);
+        }
+
+        [Fact]
+        public void CreateBusinessAttachmentRequest_EnforcesCardholderEmailByDefault()
+        {
+            var request = new CreateBusinessAttachmentRequestModel
+            {
+                Content = "SGVsbG8=",
+                Type = AttachmentType.Image,
+                UploadChannel = AttachmentUploadChannel.Email,
+                Source = "sender@pexcard.com"
+            };
+
+            Assert.True(request.EnforceCardholderEmail);
+            Assert.Contains("\"EnforceCardholderEmail\":true", JsonConvert.SerializeObject(request));
+        }
+
+        [Fact]
+        public void CreateBusinessAttachmentRequest_SerializesEnforceCardholderEmailFalse()
+        {
+            var request = new CreateBusinessAttachmentRequestModel
+            {
+                Content = "SGVsbG8=",
+                Type = AttachmentType.Image,
+                UploadChannel = AttachmentUploadChannel.Email,
+                Source = "unknown@vendor.com",
+                EnforceCardholderEmail = false
+            };
+
+            var json = JsonConvert.SerializeObject(
+                request,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+            Assert.Contains("\"EnforceCardholderEmail\":false", json);
         }
 
         [Fact]
@@ -206,6 +241,91 @@ namespace PexCard.Api.Client.Core.Tests.Serialization
             Assert.Null(model.Match.CommitDateUtc);
             Assert.Equal(1, model.Match.MatchRetryCount);
             Assert.Null(model.Match.Matched);
+        }
+
+        [Fact]
+        public void BusinessAttachment_DeserializesSourceAndLinks()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Image\",\"Size\":84213,\"MetadataId\":555," +
+                "\"FileName\":\"receipt.png\",\"UploadChannel\":\"Email\",\"Source\":\"jane@company.com\",\"Links\":{" +
+                "\"Full\":\"https://files.pexcard.com/att-1?sig=abc\"," +
+                "\"Thumbnail\":\"https://files.pexcard.com/att-1/thumb?sig=abc\"," +
+                "\"Expiration\":\"2026-06-26T15:05:11Z\"}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.Equal("jane@company.com", model.Source);
+            Assert.NotNull(model.Links);
+            Assert.Equal("https://files.pexcard.com/att-1?sig=abc", model.Links.Full);
+            Assert.Equal("https://files.pexcard.com/att-1/thumb?sig=abc", model.Links.Thumbnail);
+            Assert.Equal(new DateTime(2026, 6, 26, 15, 5, 11, DateTimeKind.Utc), model.Links.Expiration.ToUniversalTime());
+        }
+
+        [Fact]
+        public void BusinessAttachment_DeserializesLinksWithoutThumbnail()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Links\":{\"Full\":\"https://files.pexcard.com/att-1?sig=abc\"," +
+                "\"Thumbnail\":null,\"Expiration\":\"2026-06-26T15:05:11Z\"}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.NotNull(model.Links);
+            Assert.Null(model.Links.Thumbnail);
+        }
+
+        [Fact]
+        public void BusinessAttachment_DeserializesNullSourceAndLinks()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Source\":null,\"Links\":null}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.Null(model.Source);
+            Assert.Null(model.Links);
+        }
+
+        [Fact]
+        public void BusinessAttachmentMatch_DeserializesSettledTransactionIds()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Image\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Match\":{\"Status\":\"AutoMatch\"," +
+                "\"AuthTranId\":880011,\"NetworkTranId\":990022,\"TransactionId\":770033}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.Equal(880011, model.Match.AuthTranId);
+            Assert.Equal(990022, model.Match.NetworkTranId);
+            Assert.Equal(770033, model.Match.TransactionId);
+        }
+
+        [Fact]
+        public void BusinessAttachmentMatch_PendingTransaction_HasNullTransactionId()
+        {
+            // Auth-only: correlate on AuthTranId until the transaction settles and TransactionId is populated.
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Image\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Match\":{\"Status\":\"AutoMatch\"," +
+                "\"AuthTranId\":880011,\"NetworkTranId\":990022,\"TransactionId\":null}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.Equal(880011, model.Match.AuthTranId);
+            Assert.Equal(990022, model.Match.NetworkTranId);
+            Assert.Null(model.Match.TransactionId);
+        }
+
+        [Fact]
+        public void BusinessAttachmentMatch_TransactionIds_NullWhenAbsent()
+        {
+            const string json = "{\"AttachmentId\":\"att-1\",\"Type\":\"Pdf\",\"Size\":1234,\"MetadataId\":555," +
+                "\"UploadChannel\":\"Email\",\"Match\":{\"Status\":\"NoMatch\"}}";
+
+            var model = JsonConvert.DeserializeObject<BusinessAttachmentModel>(json);
+
+            Assert.Null(model.Match.AuthTranId);
+            Assert.Null(model.Match.NetworkTranId);
+            Assert.Null(model.Match.TransactionId);
         }
 
         [Fact]


### PR DESCRIPTION
Mirrors the ExternalAPI `Business/Attachments` changes so SDK consumers don't have to hand-roll requests/responses.

Work item: [AB#145692](https://pexcard.visualstudio.com/aeed64c4-c884-4a53-8682-73e24201472f/_workitems/edit/145692)
ExternalAPI PR: https://pexcard.visualstudio.com/DefaultCollection/PEX%20Processing%20Solution/_git/ExternalAPI/pullrequest/70580

## Changes

`POST /Business/Attachments` — `CreateBusinessAttachmentRequestModel`
- `EnforceCardholderEmail` (bool, defaults to `true`, so existing callers are unaffected). When false, `Source` is not resolved to a cardholder and the attachment is stored against the business, unattributed; the 404/403 unresolved-sender responses do not apply. `UploadChannel` and `Source` remain required in both modes.

`GET /Business/Attachments/{metadataId}/{attachmentId}` — `BusinessAttachmentModel`
- `Source` — the sender the receipt arrived from (email address or phone number).
- `Links` — new `BusinessAttachmentLinksModel` with presigned `Full`, `Thumbnail`, and a shared `Expiration`. Short-lived: documented as re-fetch, never store.
- `Match` gained `AuthTranId`, `NetworkTranId`, and `TransactionId`, all `long?`. `TransactionId` is the settled id `/Details` uses and is null while the transaction is pending (auth-only), so callers correlate on `AuthTranId` until it settles.

XML doc comments on `IPexApiClient.UploadBusinessAttachment` and `GetBusinessAttachment` were updated to match.

## Tests

8 new cases in `BusinessAttachmentSerializationTests` covering the `EnforceCardholderEmail` default and explicit false, `Source`/`Links` deserialization (including a missing thumbnail and all-null), and the settled / pending / absent transaction-id shapes.

`dotnet test` on `tests/PexCard.Api.Client.Core.Tests`: `Failed: 0, Passed: 104, Skipped: 0, Total: 104`. Full solution builds with 0 warnings, 0 errors.

## Not done

The acceptance criteria also ask for a NuGet version bump and a changelog entry. Neither exists in this repo — the package version comes from the `majorVersion`/`minorVersion` pipeline variables in `build/azure-pipelines.yml` (`VersionPrefix` is hardcoded `0.0.0` in the csproj files), and there is no CHANGELOG file. The version bump needs to happen in the pipeline variable group, outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBwq3QYAMv9jqKS79NANG7
